### PR TITLE
Fix search and category article links

### DIFF
--- a/public/js/category.js
+++ b/public/js/category.js
@@ -132,7 +132,8 @@ function loadCategoryArticles(categoryId, categorySlug) {
                 const author = getSafe(() => article.author);
                 const readingTime = getSafe(() => article.readingTimeMinutes);
                 const articleSlug = getSafe(() => article.slug, '');
-                
+                if (!articleSlug) return; // Skip articles without slug
+
                 const articleUrl = `/${categorySlug}/${articleSlug}`;
 
                 articlesHTML += `

--- a/public/search.html
+++ b/public/search.html
@@ -125,7 +125,7 @@
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
-    <script src="/js/config.js"></script>
+    <script src="/js/app-base.js?v=2"></script>
     <script>
 // Inline search.js to avoid loading conflicts
 document.addEventListener('DOMContentLoaded', function() {
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', function() {
   // Load categories for filter dropdown and mapping
   async function loadCategories() {
     try {
-      const categoriesSnapshot = await db.collection('categories')
+      const categoriesSnapshot = await db.collection('sections')
         .orderBy('name')
         .get();
       


### PR DESCRIPTION
## Summary
- initialize Firebase on the search page using `app-base.js`
- load sections instead of nonexistent `categories` collection on search page
- skip articles without slugs when rendering category lists

## Testing
- `npm test --silent`
- `(cd functions && npm test --silent)`

------
https://chatgpt.com/codex/tasks/task_b_687b9955229083338144d7b90ec1a039