### PR TITLE
Fix stock detail modal and improve search suggestions

### DIFF
--- a/public/stock-data.html
+++ b/public/stock-data.html
@@ -257,7 +257,7 @@
                             </div>
                         </div>
                         
-                        <div class="stock-chart-container mb-3" style="height: 300px;">
+                        <div id="stock-chart" class="stock-chart-container mb-3" style="height: 300px;">
                             <canvas id="stockChart"></canvas>
                         </div>
                         


### PR DESCRIPTION
## Summary
- fix modal markup and JS IDs so company info and charts show
- reset and reveal company description when fetching profile
- add smarter ranking for stock symbol search suggestions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687bb7e40f4883339654bcaddb19bf97