### PR TITLE
Add scheduled article generator and fix draft saving

### DIFF
--- a/functions/scheduledArticles.js
+++ b/functions/scheduledArticles.js
@@ -1,0 +1,84 @@
+// functions/scheduledArticles.js
+
+const fetch = require('node-fetch');
+const { logger, db } = require('./config');
+const aiCallables = require('./callable/ai');
+const articlesAdmin = require('./admin/articles');
+
+const CONFIG_DOC = 'config/autoArticleSchedule';
+
+function estimateReadingTime(html) {
+  if (!html) return 0;
+  const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  const words = text.split(' ').filter(Boolean);
+  return Math.max(1, Math.ceil(words.length / 225));
+}
+
+async function fetchTechHeadline(newsApiKey) {
+  try {
+    const res = await fetch(`https://newsapi.org/v2/top-headlines?category=technology&language=en&pageSize=1&apiKey=${newsApiKey}`);
+    const data = await res.json();
+    if (data && data.articles && data.articles.length > 0) {
+      return data.articles[0].title;
+    }
+  } catch (err) {
+    logger.error('Failed to fetch tech headline:', err);
+  }
+  return 'latest technology news';
+}
+
+async function fetchTechQuote() {
+  try {
+    const res = await fetch('https://api.quotable.io/random?tags=technology');
+    const data = await res.json();
+    if (data && data.content) {
+      return `${data.content} — ${data.author}`;
+    }
+  } catch (err) {
+    logger.error('Failed to fetch tech quote:', err);
+  }
+  return '';
+}
+
+async function shouldGenerateArticle(defaultFrequency) {
+  const docRef = db.doc(CONFIG_DOC);
+  const snap = await docRef.get();
+  const now = Date.now();
+  const oneDay = 24 * 60 * 60 * 1000;
+  let data = snap.exists ? snap.data() : {};
+  const frequency = data.frequency || defaultFrequency || 1;
+  const last = data.lastGeneratedAt
+    ? (data.lastGeneratedAt.toMillis ? data.lastGeneratedAt.toMillis() : new Date(data.lastGeneratedAt).getTime())
+    : 0;
+  if (now - last < oneDay / frequency) return false;
+  await docRef.set({ lastGeneratedAt: new Date(now), frequency }, { merge: true });
+  return true;
+}
+
+async function generateArticle(newsApiKey) {
+  const headline = await fetchTechHeadline(newsApiKey);
+  const aiContent = await aiCallables.generateArticleContent({ auth: { uid: 'scheduler' }, data: { prompt: headline } });
+  if (aiContent.error) {
+    logger.error('AI content generation failed:', aiContent.message);
+    return;
+  }
+  const imageData = await aiCallables.generateArticleImage({ auth: { uid: 'scheduler' }, data: { prompt: aiContent.imagePrompt, articleTitle: aiContent.title } });
+  const quote = await fetchTechQuote();
+  let content = aiContent.content;
+  if (quote) content += `<blockquote>${quote}</blockquote>`;
+  const readingTime = estimateReadingTime(content);
+  await articlesAdmin.createArticle({
+    title: aiContent.title,
+    slug: aiContent.slug,
+    excerpt: aiContent.excerpt,
+    category: aiContent.category || 'news',
+    tags: aiContent.tags || [],
+    featuredImage: imageData.imageUrl,
+    imageAltText: imageData.imageAltText,
+    content,
+    published: true,
+    readingTimeMinutes: readingTime,
+  });
+}
+
+module.exports = { shouldGenerateArticle, generateArticle };

--- a/public/admin/components/articles.js
+++ b/public/admin/components/articles.js
@@ -987,16 +987,20 @@ if (typeof window.articlesManagerInitialized === 'undefined') {
         const imageAltText = document.getElementById('featuredImageAlt').value.trim();
         const content = quillEditorInstance.root.innerHTML;
         const publishedState = isActuallyPublished; // Use the passed parameter
-        const readingTimeMinutes = estimateReadingTime(content);
+        let readingTimeMinutes = estimateReadingTime(content);
 
-        if (!title || quillEditorInstance.getLength() <= 1) {
-            alert("Title and Content are required.");
+        if (!title || (isActuallyPublished && quillEditorInstance.getLength() <= 1)) {
+            alert(isActuallyPublished ? "Title and Content are required." : "Title is required.");
             if(!title) document.getElementById('title').classList.add('is-invalid');
-            if(quillEditorInstance.getLength() <= 1) document.getElementById('editor-container').style.borderColor = 'red';
+            if(isActuallyPublished && quillEditorInstance.getLength() <= 1) document.getElementById('editor-container').style.borderColor = 'red';
             return;
         }
         document.getElementById('title').classList.remove('is-invalid');
         document.getElementById('editor-container').style.borderColor = '#ced4da';
+
+        if (!isActuallyPublished && quillEditorInstance.getLength() <= 1) {
+            readingTimeMinutes = 0;
+        }
 
 
         setButtonLoading(buttonElement.id, true);


### PR DESCRIPTION
## Summary
- fix saving drafts without content in article editor
- add scheduled article generation module
- schedule tech article creation using NewsAPI and Gemini

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_b_687be21d9578833381ae929c0ed2a928