### PR TITLE
Add scheduled article controls to admin panel

### DIFF
--- a/functions/scheduledArticles.js
+++ b/functions/scheduledArticles.js
@@ -1,0 +1,84 @@
+// functions/scheduledArticles.js
+
+const fetch = require('node-fetch');
+const { logger, db } = require('./config');
+const aiCallables = require('./callable/ai');
+const articlesAdmin = require('./admin/articles');
+
+const CONFIG_DOC = 'config/autoArticleSchedule';
+
+function estimateReadingTime(html) {
+  if (!html) return 0;
+  const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  const words = text.split(' ').filter(Boolean);
+  return Math.max(1, Math.ceil(words.length / 225));
+}
+
+async function fetchTechHeadline(newsApiKey) {
+  try {
+    const res = await fetch(`https://newsapi.org/v2/top-headlines?category=technology&language=en&pageSize=1&apiKey=${newsApiKey}`);
+    const data = await res.json();
+    if (data && data.articles && data.articles.length > 0) {
+      return data.articles[0].title;
+    }
+  } catch (err) {
+    logger.error('Failed to fetch tech headline:', err);
+  }
+  return 'latest technology news';
+}
+
+async function fetchTechQuote() {
+  try {
+    const res = await fetch('https://api.quotable.io/random?tags=technology');
+    const data = await res.json();
+    if (data && data.content) {
+      return `${data.content} — ${data.author}`;
+    }
+  } catch (err) {
+    logger.error('Failed to fetch tech quote:', err);
+  }
+  return '';
+}
+
+async function shouldGenerateArticle(defaultFrequency) {
+  const docRef = db.doc(CONFIG_DOC);
+  const snap = await docRef.get();
+  const now = Date.now();
+  const oneDay = 24 * 60 * 60 * 1000;
+  let data = snap.exists ? snap.data() : {};
+  const frequency = data.frequency || defaultFrequency || 1;
+  const last = data.lastGeneratedAt
+    ? (data.lastGeneratedAt.toMillis ? data.lastGeneratedAt.toMillis() : new Date(data.lastGeneratedAt).getTime())
+    : 0;
+  if (now - last < oneDay / frequency) return false;
+  await docRef.set({ lastGeneratedAt: new Date(now), frequency }, { merge: true });
+  return true;
+}
+
+async function generateArticle(newsApiKey) {
+  const headline = await fetchTechHeadline(newsApiKey);
+  const aiContent = await aiCallables.generateArticleContent({ auth: { uid: 'scheduler' }, data: { prompt: headline } });
+  if (aiContent.error) {
+    logger.error('AI content generation failed:', aiContent.message);
+    return;
+  }
+  const imageData = await aiCallables.generateArticleImage({ auth: { uid: 'scheduler' }, data: { prompt: aiContent.imagePrompt, articleTitle: aiContent.title } });
+  const quote = await fetchTechQuote();
+  let content = aiContent.content;
+  if (quote) content += `<blockquote>${quote}</blockquote>`;
+  const readingTime = estimateReadingTime(content);
+  await articlesAdmin.createArticle({
+    title: aiContent.title,
+    slug: aiContent.slug,
+    excerpt: aiContent.excerpt,
+    category: aiContent.category || 'news',
+    tags: aiContent.tags || [],
+    featuredImage: imageData.imageUrl,
+    imageAltText: imageData.imageAltText,
+    content,
+    published: true,
+    readingTimeMinutes: readingTime,
+  });
+}
+
+module.exports = { shouldGenerateArticle, generateArticle };

--- a/public/admin/components/articles.js
+++ b/public/admin/components/articles.js
@@ -987,16 +987,20 @@ if (typeof window.articlesManagerInitialized === 'undefined') {
         const imageAltText = document.getElementById('featuredImageAlt').value.trim();
         const content = quillEditorInstance.root.innerHTML;
         const publishedState = isActuallyPublished; // Use the passed parameter
-        const readingTimeMinutes = estimateReadingTime(content);
+        let readingTimeMinutes = estimateReadingTime(content);
 
-        if (!title || quillEditorInstance.getLength() <= 1) {
-            alert("Title and Content are required.");
+        if (!title || (isActuallyPublished && quillEditorInstance.getLength() <= 1)) {
+            alert(isActuallyPublished ? "Title and Content are required." : "Title is required.");
             if(!title) document.getElementById('title').classList.add('is-invalid');
-            if(quillEditorInstance.getLength() <= 1) document.getElementById('editor-container').style.borderColor = 'red';
+            if(isActuallyPublished && quillEditorInstance.getLength() <= 1) document.getElementById('editor-container').style.borderColor = 'red';
             return;
         }
         document.getElementById('title').classList.remove('is-invalid');
         document.getElementById('editor-container').style.borderColor = '#ced4da';
+
+        if (!isActuallyPublished && quillEditorInstance.getLength() <= 1) {
+            readingTimeMinutes = 0;
+        }
 
 
         setButtonLoading(buttonElement.id, true);

--- a/public/admin/components/settings.js
+++ b/public/admin/components/settings.js
@@ -88,23 +88,42 @@ function loadSettingsPanel() {
                   <label for="facebook-url" class="form-label">Facebook URL</label>
                   <input type="url" class="form-control" id="facebook-url" name="facebookUrl">
                 </div>
-                
+
                 <div class="mb-3">
                   <label for="twitter-url" class="form-label">Twitter URL</label>
                   <input type="url" class="form-control" id="twitter-url" name="twitterUrl">
                 </div>
-                
+
                 <div class="mb-3">
                   <label for="instagram-url" class="form-label">Instagram URL</label>
                   <input type="url" class="form-control" id="instagram-url" name="instagramUrl">
                 </div>
-                
+
                 <div class="mb-3">
                   <label for="linkedin-url" class="form-label">LinkedIn URL</label>
                   <input type="url" class="form-control" id="linkedin-url" name="linkedinUrl">
                 </div>
-                
+
                 <button type="submit" class="btn btn-primary">Save Social Media Links</button>
+              </form>
+            </div>
+          </div>
+
+          <div class="card mb-4">
+            <div class="card-header">
+              <h5 class="mb-0">Auto Article Generation</h5>
+            </div>
+            <div class="card-body">
+              <form id="auto-article-settings-form">
+                <div class="mb-3">
+                  <label for="article-frequency" class="form-label">Articles Per Day</label>
+                  <select class="form-select" id="article-frequency">
+                    <option value="1">Once Daily</option>
+                    <option value="2">Twice Daily</option>
+                    <option value="3">Three Times Daily</option>
+                  </select>
+                </div>
+                <button type="submit" class="btn btn-primary">Save Auto Article Settings</button>
               </form>
             </div>
           </div>
@@ -115,6 +134,7 @@ function loadSettingsPanel() {
 
   // Load existing settings
   loadSettings();
+  loadAutoArticleSettings();
   
   // Add event listeners to forms
   document.getElementById('general-settings-form').addEventListener('submit', function(e) {
@@ -144,6 +164,12 @@ function loadSettingsPanel() {
       instagramUrl: document.getElementById('instagram-url').value,
       linkedinUrl: document.getElementById('linkedin-url').value,
     });
+  });
+
+  document.getElementById('auto-article-settings-form').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const freq = parseInt(document.getElementById('article-frequency').value, 10) || 1;
+    saveAutoArticleFrequency(freq);
   });
   
   // Add logo selection functionality
@@ -214,7 +240,7 @@ function loadSettings() {
 
 function saveSettings(type, data) {
   data.updatedAt = firebase.firestore.FieldValue.serverTimestamp();
-  
+
   settingsCollection.doc(type).set(data, { merge: true })
     .then(() => {
       showToast(`${type.charAt(0).toUpperCase() + type.slice(1)} settings saved successfully`, 'success');
@@ -222,6 +248,30 @@ function saveSettings(type, data) {
     .catch(error => {
       console.error(`Error saving ${type} settings:`, error);
       showToast(`Error saving ${type} settings: ${error.message}`, 'danger');
+    });
+}
+
+function loadAutoArticleSettings() {
+  db.doc('config/autoArticleSchedule').get()
+    .then(doc => {
+      if (doc.exists) {
+        const data = doc.data();
+        document.getElementById('article-frequency').value = data.frequency || 1;
+      }
+    })
+    .catch(err => {
+      console.error('Error loading auto article settings:', err);
+    });
+}
+
+function saveAutoArticleFrequency(freq) {
+  db.doc('config/autoArticleSchedule').set({ frequency: freq }, { merge: true })
+    .then(() => {
+      showToast('Auto article settings saved', 'success');
+    })
+    .catch(err => {
+      console.error('Error saving auto article settings:', err);
+      showToast('Error saving auto article settings', 'danger');
     });
 }
 


### PR DESCRIPTION
## Summary
- add Auto Article Generation form to settings panel
- load and save article frequency via Firestore

## Testing
- `npm test --silent -- --passWithNoTests`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_b_687be21d9578833381ae929c0ed2a928