### PR TITLE
Add Automation by Meir sidebar banner

### DIFF
--- a/public/article.html
+++ b/public/article.html
@@ -91,6 +91,13 @@
                     </ul>
                 </div>
 
+                <div class="sidebar-section automation-banner mb-4">
+                    <a href="https://www.automationbymeir.com/" target="_blank" rel="noopener" class="automation-banner-link">
+                        <h4 class="mb-2">Automation by Meir</h4>
+                        <p class="small mb-0">Transform your business with custom automation</p>
+                    </a>
+                </div>
+
                 <!-- Sidebar Ad -->
                 <div class="ad-container text-center">
                     <p class="text-muted mb-1 small">Advertisement</p>

--- a/public/index.html
+++ b/public/index.html
@@ -164,8 +164,15 @@
             <div id="sidebar-podcasts-error" class="alert alert-warning small d-none" role="alert">
               Could not load podcasts.
             </div>
-            <div id="sidebar-podcasts-list"></div>
-          </div>
+        <div id="sidebar-podcasts-list"></div>
+        </div>
+        </div>
+
+        <div class="sidebar-section automation-banner mb-5">
+          <a href="https://www.automationbymeir.com/" target="_blank" rel="noopener" class="automation-banner-link">
+            <h4 class="mb-2">Automation by Meir</h4>
+            <p class="small mb-0">Transform your business with custom automation</p>
+          </a>
         </div>
       </aside>
     </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -629,3 +629,35 @@ main > .container > section {
 .mb-4 { margin-bottom: var(--spacing-lg) !important; }
 .py-3 { padding-top: var(--spacing-md); padding-bottom: var(--spacing-md); }
 .py-5 { padding-top: var(--spacing-xl); padding-bottom: var(--spacing-xl); }
+
+/* --- Automation by Meir Banner --- */
+.automation-banner {
+  background: linear-gradient(135deg, #4285F4 0%, #34A853 100%);
+  color: #fff;
+  text-align: center;
+  border: none;
+  box-shadow: var(--shadow-deep);
+}
+
+.automation-banner-link {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+}
+
+.automation-banner h4 {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  margin-bottom: var(--spacing-sm);
+  color: inherit;
+}
+
+.automation-banner p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.automation-banner:hover {
+  transform: translateY(-2px);
+}


### PR DESCRIPTION
## Summary
- add sidebar promotion banner for Automation by Meir on homepage and article pages
- style the banner with a gradient background

## Testing
- `npm run lint`
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_687c98610c8c8333b635fc7f4019bdbc