### PR TITLE
Add Hebrew RTL version of site

### DIFF
--- a/public/article-sample-he.html
+++ b/public/article-sample-he.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>בינה מלאכותית בעולם העסקים</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="css/rtl.css">
+</head>
+<body class="container py-4">
+<h1>בינה מלאכותית בעולם העסקים</h1>
+<p>במאמר זה נסקור כיצד טכנולוגיות בינה מלאכותית משנות את פני התעשייה ומאפשרות לעסקים להתייעל.</p>
+<p>השימוש באלגוריתמים מתקדמים מאפשר ניתוח נתונים מהיר ומדויק יותר, קבלת החלטות מושכלת ושיפור תהליכים קיימים.</p>
+<p>זהו מאמר לדוגמה בעברית.</p>
+</body>
+</html>

--- a/public/css/rtl.css
+++ b/public/css/rtl.css
@@ -1,0 +1,4 @@
+body {
+  direction: rtl;
+  text-align: right;
+}

--- a/public/index-he.html
+++ b/public/index-he.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>טק יומי - חדשות וטכנולוגיה</title>
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-M68CNVMQ');</script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-functions-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
+<!-- Add this in your <head> section -->
+
+  <link rel="canonical" href="https://trendingtechdaily.com/" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=IBM+Plex+Sans:wght@400;600&family=Fira+Code&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="css/ai-agent.css">
+  <link rel="stylesheet" href="css/popup.css" />
+  <link rel="stylesheet" href="css/sidebar-podcasts.css" />
+  <link rel="stylesheet" href="css/rtl.css" />
+
+
+
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8142734137865758"
+    crossorigin="anonymous"></script>
+    <link rel="icon" href="/favicon.ico" sizes="any"> <link rel="icon" href="/favicon.svg" type="image/svg+xml"> <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+   
+
+  </head>
+<body>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M68CNVMQ"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- Navbar Placeholder -->
+  <div id="navbar-placeholder"></div>
+  <!-- Welcome Popup -->
+  <div id="welcome-popup-overlay" class="welcome-popup-overlay">
+    <div class="welcome-popup">
+      <div class="welcome-popup-header">
+        <button class="popup-close-btn" id="popup-close-btn" type="button" aria-label="Close popup">
+          <i class="bi bi-x"></i>
+        </button>
+        <div class="welcome-icon">
+          <i class="bi bi-hand-thumbs-up"></i>
+        </div>
+        <h2>Welcome to TrendingTech Daily!</h2>
+        <p>Join our community and unlock exclusive features to enhance your tech news experience.</p>
+      </div>
+      
+      <div class="welcome-popup-body">
+        <div class="benefits-grid">
+          <div class="benefit-card">
+            <div class="benefit-icon">
+              <i class="bi bi-bookmark-heart"></i>
+            </div>
+            <h4>Save Articles</h4>
+            <p>Bookmark articles for later reading and build your personal tech knowledge library.</p>
+          </div>
+          
+          <div class="benefit-card">
+            <div class="benefit-icon">
+              <i class="bi bi-eye-fill"></i>
+            </div>
+            <h4>Track Reading</h4>
+            <p>Keep track of articles you've read and discover personalized recommendations.</p>
+          </div>
+          
+          <div class="benefit-card">
+            <div class="benefit-icon">
+              <i class="bi bi-chat-dots"></i>
+            </div>
+            <h4>Join Discussions</h4>
+            <p>Leave comments, engage with other tech enthusiasts, and share your insights.</p>
+          </div>
+          
+          <div class="benefit-card">
+            <div class="benefit-icon">
+              <i class="bi bi-graph-up"></i>
+            </div>
+            <h4>Stock Wishlist</h4>
+            <p>Create a personalized watchlist to track your favorite tech stocks and investments.</p>
+          </div>
+        </div>
+        
+        <div class="popup-actions">
+          <a href="/signup.html" class="popup-btn popup-btn-primary">
+            <i class="bi bi-person-plus"></i>
+            Create Free Account
+          </a>
+          <button class="popup-btn popup-btn-secondary" id="popup-maybe-later">
+            Maybe Later
+          </button>
+        </div>
+      </div>
+      
+      <div class="popup-footer">
+        <p>Already have an account? <a href="/login.html">Sign in here</a></p>
+      </div>
+    </div>
+  </div>
+ <!-- Banner location -->
+    </div>
+  </header>
+
+  
+
+  <section class="container mb-5" id="featured-article-container">
+    <div class="spinner-container text-center py-5">
+      <div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div>
+      <p>טוען מאמר נבחר...</p>
+    </div>
+  </section>
+  <section class="container mt-5 mb-4 video-recommendations">
+    <h2 class="section-title">סרטונים מומלצים</h2>
+    <div id="video-loader" class="spinner-container text-center py-4">
+         <div class="spinner-border text-secondary spinner-border-sm" role="status"></div>
+         <p class="text-muted small mt-2">טוען סרטונים...</p>
+    </div>
+    <div id="video-recommendations-container" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+        </div>
+
+        <div id="show-more-videos-container" class="text-center mt-4" style="display: none;">
+          <button id="show-more-videos-btn" class="btn btn-outline-secondary btn-sm">הצג עוד סרטונים</button>
+          <button id="show-less-videos-btn" class="btn btn-outline-secondary btn-sm" style="display: none;">הצג פחות סרטונים</button> </div>
+    </section>
+  <main class="container">
+    <div class="row">
+      <div class="col-lg-8">
+        <h2 class="section-title">המאמרים האחרונים</h2>
+        <div id="articles-container">
+          <div class="spinner-container text-center py-5"><div class="spinner-border" role="status"></div><p>טוען מאמרים...</p></div>
+        </div>
+      </div>
+      <aside class="col-lg-4">
+        <div class="sidebar-section mb-5">
+          <h4>נושאים חמים</h4>
+          <ul class="trending-topics-list" id="categories-list">
+            <div class="spinner-container py-2 text-center"><div class="spinner-border spinner-border-sm" role="status"></div></div>
+          </ul>
+        </div>
+        <div class="sidebar-section mb-5">
+          <div class="section-header d-flex justify-content-between align-items-center mb-3">
+            <h4>פודקאסטים מומלצים</h4>
+            <a href="/podcasts.html" class="btn btn-outline-primary btn-sm">
+              <i class="bi bi-headphones me-1"></i>צפה בהכל
+            </a>
+          </div>
+          <div id="sidebar-podcasts-container">
+            <div id="sidebar-podcasts-loader" class="text-center py-3">
+              <div class="spinner-border spinner-border-sm text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+              </div>
+              <p class="small text-muted mt-2">טוען פודקאסטים...</p>
+            </div>
+            <div id="sidebar-podcasts-error" class="alert alert-warning small d-none" role="alert">
+              Could not load podcasts.
+            </div>
+        <div id="sidebar-podcasts-list"></div>
+        </div>
+        </div>
+
+        <div class="sidebar-section automation-banner mb-5">
+          <a href="https://www.automationbymeir.com/" target="_blank" rel="noopener" class="automation-banner-link">
+            <h4 class="mb-2">Automation by Meir</h4>
+            <p class="small mb-0">Transform your business with custom automation</p>
+          </a>
+        </div>
+      </aside>
+    </div>
+  </main>
+
+  <footer class="footer">
+      <div class="container">
+          <div class="row">
+              <div class="col-md-3 mb-4 mb-md-0"><h5 id="footer-site-title">TrendingTech Daily</h5><p id="footer-description" class="small text-muted">Stay informed...</p></div>
+              <div class="col-md-3 mb-4 mb-md-0"><h5>Quick Links</h5><ul class="footer-links"><li><a href="/">Home</a></li><li><a href="/about.html">About Us</a></li><li><a href="/privacy.html">Privacy Policy</a></li><li><a href="/terms.html">Terms of Service</a></li></ul></div>
+              <div class="col-md-3 mb-4 mb-md-0"><h5>Categories</h5><ul class="footer-links" id="footer-categories-list"><li class="text-muted small fst-italic">Coming soon</li></ul></div>
+              <div class="col-md-3"><h5>Contact Us</h5><p class="small"><i class="bi bi-envelope-fill me-1"></i><span id="contact-email">Coming soon</span><br><i class="bi bi-geo-alt-fill me-1"></i><span id="contact-address">Coming soon</span></p><div id="footer-social-links" class="mt-2"></div></div>
+          </div>
+          <div class="copyright"> <span id="footer-text">2025 TrendingTech Daily.</span></div>
+      </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+  <script src="js/app-base.js"></script>
+  <script src="js/index-main.js"></script>
+  <script src="js/index-features.js"></script>
+  <script src="js/ai-agent.js" defer></script>
+  <script src="/js/config.js"></script>
+    <script src="/js/auth.js"></script>
+    <script src="/js/nav-loader.js"></script>
+    <script src="js/index-he.js"></script>
+<!-- SINGLE AI-AGENT CONTAINER -->
+<div class="ai-agent-container" id="aiAgentContainer">
+  <button class="ai-agent-button" id="aiAgentButton" aria-label="AI Tech News Assistant">
+    <div class="ai-agent-pulse"></div>
+    <svg class="ai-agent-icon" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+    </svg>
+  </button>
+  <div class="ai-agent-chat" id="aiAgentChat">
+    <div class="ai-chat-header">
+      <h3>
+        <span class="ai-status-indicator"></span>
+        AI Tech News Agent
+      </h3>
+      <button class="ai-chat-close" id="aiChatClose" aria-label="Close chat">
+        <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+        </svg>
+      </button>
+    </div>
+    <div class="ai-chat-content">
+      <div class="ai-chat-messages" id="aiChatMessages">
+        <div class="ai-message bot">
+          <div class="ai-message-bubble">
+            Hello! I'm your AI assistant for TrendingTech Daily. I can help you find articles, explain tech concepts, or discuss the latest tech news. How can I assist you today?
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="ai-chat-input">
+      <div class="ai-quick-actions">
+        <button class="ai-quick-action" data-action="What's trending today?">What's trending?</button>
+        <button class="ai-quick-action" data-action="Explain this article">Explain article</button>
+        <button class="ai-quick-action" data-action="Find AI news">AI news</button>
+      </div>
+      <form class="ai-input-form" id="aiInputForm">
+        <input type="text" class="ai-input-field" id="aiInputField" placeholder="Ask me anything..." autocomplete="off">
+        <button type="submit" class="ai-send-button" id="aiSendButton" disabled>
+          <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>
+          </svg>
+        </button>
+      </form>
+    </div>
+  </div>
+</div>
+  <!-- BANNER POINTER (positioned at bottom) -->
+  <div class="ai-agent-banner-pointer" id="aiAgentBannerPointer">
+    <div class="ai-agent-banner">
+      <button class="dismiss-btn" id="aiAgentBannerDismiss" aria-label="Dismiss banner">
+        <i class="bi bi-x"></i>
+      </button>
+      <div class="banner-content">
+        <div class="banner-title">
+          <h2>AI Tech Assistant</h2>
+        </div>
+        <p class="subtitle">Your personal guide to the latest in tech.</p>
+      </div>
+      <div class="banner-arrow-container">
+        <div class="banner-arrow"></div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/js/index-features.js
+++ b/public/js/index-features.js
@@ -55,7 +55,7 @@ async function loadRecommendedVideos() {
         console.log("Calling getRecommendedVideos Cloud Function...");
         const getVideosCallable = functions.httpsCallable('getRecommendedVideos');
 
-        const searchKeywords = ['latest technology', 'ai innovation', 'gadget reviews', 'tech news'];
+        const searchKeywords = window.videoKeywords || ['latest technology', 'ai innovation', 'gadget reviews', 'tech news'];
         const result = await getVideosCallable({ keywords: searchKeywords, maxResults: 6 });
 
         const videoData = getSafe(() => result.data.videos, []);
@@ -365,7 +365,8 @@ async function loadSidebarPodcasts() {
         const getTechPodcastsFn = functions.httpsCallable('getTechPodcasts');
 
         const result = await getTechPodcastsFn({
-            query: "technology podcast programming ai",
+            query: window.podcastQuery || "technology podcast programming ai",
+            market: window.podcastMarket || "US",
             limit: 4
         });
 

--- a/public/js/index-he.js
+++ b/public/js/index-he.js
@@ -1,0 +1,54 @@
+// Overrides for Hebrew version
+window.language = 'he';
+window.videoKeywords = ['חדשות טכנולוגיה', 'חדשנות', 'סקירות גאדג׳טים'];
+window.podcastQuery = 'פודקאסט טכנולוגיה';
+window.podcastMarket = 'IL';
+
+const hebrewArticles = [
+  {
+    id: 'he1',
+    title: 'בינה מלאכותית בעולם העסקים',
+    excerpt: 'כיצד AI משנה את פני התעשייה.',
+    slug: '#',
+    createdAt: { toDate: () => new Date() },
+    featuredImage: '/img/default-podcast-art.png',
+    readingTimeMinutes: 3,
+    category: 'General'
+  },
+  {
+    id: 'he2',
+    title: 'הגאדג\'ט החדש שמשגע את כולם',
+    excerpt: 'סקירה מהירה של המכשיר החם בשוק.',
+    slug: '#',
+    createdAt: { toDate: () => new Date() },
+    featuredImage: '/img/default-podcast-art.png',
+    readingTimeMinutes: 2,
+    category: 'Gadgets'
+  },
+  {
+    id: 'he3',
+    title: 'מדריך קצר לאבטחת סייבר',
+    excerpt: 'טיפים חשובים לשמירה על פרטיותך.',
+    slug: '#',
+    createdAt: { toDate: () => new Date() },
+    featuredImage: '/img/default-podcast-art.png',
+    readingTimeMinutes: 4,
+    category: 'Security'
+  }
+];
+
+function loadFeaturedArticle() {
+  const container = document.getElementById('featured-article-container');
+  if (!container) return;
+  const doc = { id: hebrewArticles[0].id, data: () => hebrewArticles[0] };
+  renderArticle(doc, container, true);
+}
+
+function loadLatestArticles() {
+  const container = document.getElementById('articles-container');
+  if (!container) return;
+  container.innerHTML = '';
+  hebrewArticles.slice(0, 3).forEach(article => {
+    container.innerHTML += renderArticleCard(article);
+  });
+}

--- a/public/js/nav-loader.js
+++ b/public/js/nav-loader.js
@@ -25,6 +25,7 @@ function initializeNavigation() {
     // These are now guaranteed to run after nav.html is in the DOM
     initializeSearch();
     initializeResponsiveCategories();
+    initializeLanguageSwitch();
 
     // Initialize user authentication state if the function exists
     if (window.initializeAuth) {
@@ -319,6 +320,18 @@ function loadFooterCategories() {
       console.error('Error loading footer categories:', error);
       footerCategoriesList.innerHTML = '<li class="text-muted">Unable to load categories</li>';
     });
+}
+
+function initializeLanguageSwitch() {
+  const link = document.getElementById('language-switch-link');
+  if (!link) return;
+  if (window.language === 'he') {
+    link.textContent = 'English';
+    link.href = '/index.html';
+  } else {
+    link.textContent = 'עברית';
+    link.href = '/index-he.html';
+  }
 }
 
 // Wait for Firebase to be ready

--- a/public/nav.html
+++ b/public/nav.html
@@ -29,6 +29,9 @@
               <i class="bi bi-search"></i>
             </a>
         </li>
+        <li class="nav-item" id="language-switch-item">
+          <a class="nav-link" id="language-switch-link" href="/index-he.html">עברית</a>
+        </li>
 
         <!-- Updated user dropdown with profile picture -->
         <li class="nav-item dropdown">


### PR DESCRIPTION
## Summary
- create a simple RTL stylesheet
- add Hebrew homepage and sample Hebrew article
- let nav offer a language switch link
- allow overriding of video and podcast search keywords via globals
- provide Hebrew overrides using a new script

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688534f54a708333a36641cef57c9a90