### PR TITLE
Add Hebrew version pages and dynamic translations

### DIFF
--- a/public/article-he.html
+++ b/public/article-he.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Article - TrendingTech Daily</title>
+    
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M68CNVMQ');</script>
+    <script>window.language = "he";</script>
+    
+    <!-- Firebase -->
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-functions-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-storage-compat.js"></script>
+
+    <!-- Styles -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700;900&family=Source+Serif+Pro:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/css/ai-agent.css">
+    <link rel="stylesheet" href="/css/rtl.css">
+    
+    <!-- Article Code Snippet Styles -->
+    <link rel="stylesheet" href="/css/article-code.css">
+    
+    <!-- Prism.js for code highlighting -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    
+    <!-- AdSense -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8142734137865758" crossorigin="anonymous"></script>
+</head>
+<body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M68CNVMQ"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    
+    <!-- Navbar Placeholder -->
+    <div id="navbar-placeholder"></div>
+
+    <!-- Main Content -->
+    <div class="container mt-4 mb-5">
+        <div class="row">
+            <!-- Article Column -->
+            <div class="col-lg-8">
+                <!-- Article Container -->
+                <div id="article-container">
+                    <div class="spinner-container text-center py-5">
+                        <div class="spinner-border text-primary" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                        <p class="text-muted mt-2">Loading article...</p>
+                    </div>
+                </div>
+
+                <!-- Related Articles -->
+                <div class="related-articles mt-5" id="related-articles-container" style="display: none;">
+                    <h3 class="section-title">Related Articles</h3>
+                    <div class="row g-3" id="related-articles-list"></div>
+                </div>
+                
+                <!-- Advertisement -->
+                <div class="ad-container my-4 text-center">
+                    <hr>
+                    <p class="text-muted small mb-2">Advertisement</p>
+                    <iframe src="https://www.fiverr.com/gig_widgets?id=U2FsdGVkX19Swkh+R4Km+WCOEHylAuvdb5hVh/hagr09NnGaLFnuFZFgo+VxZxgp+V7tsbus+6Qy9BTItznEyUzdaC211ywZboShwUMuZPoxmTBHjqj0+tmw79+OnPph+yE0rhMZgmDLJQFI4omAS4yBfTPa/htI8ZUD0lfviR1tIlZ5NnSu8TuEp00dg0cjveQgIbCgp+xijyNL1Ae8PHaMAeqBtB7yB8DG8NySd1zg63gPrw34oOaJf2fyY7vDZZm3nKtg8boiY/5eW0lzON5IuJ/YFhXOjpiPP9I+Mc+nlFLXETULNOgqvjAtL32jp8oKdfBrE/pLCj5J+iiKyf+kNf9ekO+IMm0T6LgFra1nr9Wzs3JSRGbunzuLD59cLjHFV1VcpGwrrJTigauNVhCilZKCZb9YYc8G/seAXMxatBUg2VVNWZ2vljS2nHmBwUD6uRZ91AgQ9aOLMPoNwg==&affiliate_id=1123441&strip_google_tagmanager=true" loading="lazy" data-with-title="true" class="fiverr_nga_frame" frameborder="0" height="500" width="100%" referrerpolicy="no-referrer-when-downgrade" data-mode="random_gigs" onload=" var frame = this; var script = document.createElement('script'); script.addEventListener('load', function() { window.FW_SDK.register(frame); }); script.setAttribute('src', 'https://www.fiverr.com/gig_widgets/sdk'); document.body.appendChild(script); " ></iframe>
+                    <hr class="mt-4">
+                </div>
+            </div>
+
+            <!-- Sidebar -->
+            <aside class="col-lg-4">
+                <!-- Trending Articles -->
+                <div class="sidebar-section mb-4">
+                    <h4>Trending Articles</h4>
+                    <ul class="trending-topics-list" id="trending-articles-list">
+                        <li class="text-muted small">Loading...</li>
+                    </ul>
+                </div>
+
+                <!-- Categories -->
+                <div class="sidebar-section mb-4">
+                    <h4>Categories</h4>
+                    <ul class="trending-topics-list" id="categories-list">
+                        <li class="text-muted small">Loading...</li>
+                    </ul>
+                </div>
+
+                <div class="sidebar-section automation-banner mb-4">
+                    <a href="https://www.automationbymeir.com/" target="_blank" rel="noopener" class="automation-banner-link">
+                        <h4 class="mb-2">Automation by Meir</h4>
+                        <p class="small mb-0">Transform your business with custom automation</p>
+                    </a>
+                </div>
+
+                <!-- Sidebar Ad -->
+                <div class="ad-container text-center">
+                    <p class="text-muted mb-1 small">Advertisement</p>
+                    <div class="bg-light d-flex align-items-center justify-content-center" style="height: 250px; width: 100%;">
+                        <div></div>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <div id="footer-placeholder"></div>
+
+    <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/app-base.js?v=2"></script>
+    <script src="/js/category-helper.js"></script> 
+    <script src="/js/ai-agent.js" defer></script>
+    
+    <!-- Prism.js for code highlighting (must be before article-page.js) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
+
+    <!-- Page-specific Scripts -->
+    <script src="/js/article-page.js"></script>
+    <script src="/js/auth.js"></script>
+    <script src="/js/nav-loader.js"></script>
+    <script src="/js/article-he.js"></script>
+
+    <!-- AI Agent Container -->
+    <div class="ai-agent-container" id="aiAgentContainer">
+        <button class="ai-agent-button" id="aiAgentButton" aria-label="AI Tech News Assistant">
+            <div class="ai-agent-pulse"></div>
+            <svg class="ai-agent-icon" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+            </svg>
+        </button>
+        
+        <div class="ai-agent-chat" id="aiAgentChat">
+            <div class="ai-chat-header">
+                <h3>
+                    <span class="ai-status-indicator"></span>
+                    AI Tech News Agent
+                </h3>
+                <button class="ai-chat-close" id="aiChatClose" aria-label="Close chat">
+                    <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                    </svg>
+                </button>
+            </div>
+            
+            <div class="ai-chat-content">
+                <div class="ai-chat-messages" id="aiChatMessages">
+                    <div class="ai-message bot">
+                        <div class="ai-message-bubble">
+                            Hello! I'm your AI assistant for TrendingTech Daily. I can help you find articles, explain tech concepts, or discuss the latest tech news. How can I assist you today?
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="ai-chat-input">
+                <div class="ai-quick-actions">
+                    <button class="ai-quick-action" data-action="What's trending today?">What's trending?</button>
+                    <button class="ai-quick-action" data-action="Explain this article">Explain article</button>
+                    <button class="ai-quick-action" data-action="Find AI news">AI news</button>
+                </div>
+                <form class="ai-input-form" id="aiInputForm">
+                    <input 
+                        type="text" 
+                        class="ai-input-field" 
+                        id="aiInputField" 
+                        placeholder="Ask me anything..."
+                        autocomplete="off"
+                    >
+                    <button type="submit" class="ai-send-button" id="aiSendButton" disabled>
+                        <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
+                            <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>
+                        </svg>
+                    </button>
+                </form>
+            </div>
+        </div>
+        <!-- BANNER POINTER (positioned at bottom) -->
+  <div class="ai-agent-banner-pointer" id="aiAgentBannerPointer">
+    <div class="ai-agent-banner">
+      <button class="dismiss-btn" id="aiAgentBannerDismiss" aria-label="Dismiss banner">
+        <i class="bi bi-x"></i>
+      </button>
+      <div class="banner-content">
+        <div class="banner-title">
+          <h2>Summerize the article</h2>
+        </div>
+        <p class="subtitle">With our advanced AI assistant</p>
+      </div>
+      <div class="banner-arrow-container">
+        <div class="banner-arrow"></div>
+      </div>
+    </div>
+  </div>
+    </div>
+</body>
+</html>

--- a/public/category-he.html
+++ b/public/category-he.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Category - TrendingTech Daily</title>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M68CNVMQ');</script>
+    <script>window.language = "he";</script>
+    
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-functions-compat.js"></script>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=IBM+Plex+Sans:wght@400;600&family=Fira+Code&display=swap" rel="stylesheet">
+    
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
+    
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="css/rtl.css">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8142734137865758"
+     crossorigin="anonymous"></script>
+</head>
+<body>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M68CNVMQ"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <div id="navbar-placeholder"></div>
+    
+    <header class="category-header">
+        <div class="container">
+            <h1 id="category-title">Loading Category...</h1>
+            <p id="category-description"></p>
+        </div>
+    </header>
+    
+    <main class="container">
+        <div class="row">
+            <div class="col-lg-8">
+                <div id="articles-container">
+                    <div class="spinner-container">
+                        <div class="spinner-border" role="status">
+                            <span class="visually-hidden">Loading...</span>
+                        </div>
+                        <p>Loading articles...</p>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-lg-4">
+                <div class="sidebar-section">
+                    <h4>All Categories</h4>
+                    <ul class="trending-topics-list" id="categories-list">
+                        <li>Loading categories...</li>
+                    </ul>
+                </div>
+                
+                <div class="sidebar-section">
+                    <h4>Recent Articles</h4>
+                    <ul class="trending-topics-list" id="recent-articles-list">
+                        <li>Loading recent articles...</li>
+                    </ul>
+                </div>
+                
+                <div class="ad-container">
+                    <p class="text-muted mb-1">Advertisement</p>
+                    <div class="bg-light" style="height: 250px; display: flex; align-items: center; justify-content: center;">
+                        <p class="text-muted">Your Ad Here</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+    
+    <!-- Footer Placeholder -->
+    <div id="footer-placeholder"></div>
+    
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="js/app-base.js?v=2"></script>
+    <script src="/js/category-helper.js"></script>
+    <script src="js/category.js?v=6"></script>
+    <script src="/js/auth.js"></script>
+    <script src="/js/nav-loader.js"></script>
+    <script>
+    // Force category loading after all scripts are loaded
+    document.addEventListener('DOMContentLoaded', function() {
+        // Wait a bit for all other scripts to initialize
+        setTimeout(function() {
+            console.log('Force loading category from inline script');
+            
+            // Get the slug from URL or sessionStorage
+            let categorySlug = null;
+            
+            // Check sessionStorage first
+            const routingInfo = sessionStorage.getItem('categoryRouting');
+            if (routingInfo) {
+                categorySlug = routingInfo;
+                sessionStorage.removeItem('categoryRouting');
+                console.log('Found slug in sessionStorage:', categorySlug);
+            } else {
+                // Check URL
+                const pathParts = window.location.pathname.split('/').filter(part => part && part !== '');
+                if (pathParts.length === 1 && !pathParts[0].includes('.html')) {
+                    categorySlug = pathParts[0];
+                    console.log('Found slug in URL:', categorySlug);
+                } else {
+                    // Check query params
+                    const urlParams = new URLSearchParams(window.location.search);
+                    categorySlug = urlParams.get('slug');
+                    console.log('Found slug in query params:', categorySlug);
+                }
+            }
+            
+            if (categorySlug && typeof loadCategory === 'function') {
+                console.log('Calling loadCategory with slug:', categorySlug);
+                loadCategory(categorySlug);
+                
+                // Also load sections if not already loaded
+                if (typeof loadSections === 'function') {
+                    loadSections();
+                }
+            } else {
+                console.error('No category slug found or loadCategory function not available');
+            }
+        }, 500); // Wait 500ms for everything to initialize
+    });
+    </script>
+
+</body>
+</html>

--- a/public/footer-he.html
+++ b/public/footer-he.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-3 mb-4 mb-md-0">
-                <h5 id="footer-site-title">טק יומי</h5>
+                <h5 id="footer-site-title">TrendingTech Daily</h5>
                 <p id="footer-description" class="small text-muted">השארו מעודכנים בכל מה שחם בעולם הטכנולוגיה.</p>
             </div>
             <div class="col-md-3 mb-4 mb-md-0">
@@ -29,7 +29,7 @@
             </div>
         </div>
         <div class="copyright">
-            <span id="footer-text">2025 טק יומי.</span>
+            <span id="footer-text">2025 TrendingTech Daily.</span>
         </div>
     </div>
 </footer>

--- a/public/index-he.html
+++ b/public/index-he.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>טק יומי - חדשות וטכנולוגיה</title>
+  <title>TrendingTech Daily - חדשות טכנולוגיה</title>
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/public/js/article-he.js
+++ b/public/js/article-he.js
@@ -1,0 +1,42 @@
+// article-he.js - translation support for Hebrew article page
+window.language = 'he';
+
+function translateText(text) {
+  return fetch(`https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=he&dt=t&q=${encodeURIComponent(text)}`)
+    .then(r => r.json())
+    .then(d => d[0][0][0])
+    .catch(() => text);
+}
+
+async function translateArticle() {
+  const titleEl = document.querySelector('.article-title');
+  if (titleEl) {
+    titleEl.textContent = await translateText(titleEl.textContent.trim());
+  }
+  const metaDesc = document.querySelector('.article-description');
+  if (metaDesc) {
+    metaDesc.textContent = await translateText(metaDesc.textContent.trim());
+  }
+  const body = document.querySelector('.article-body-content');
+  if (body) {
+    const translated = await translateText(body.textContent.trim());
+    body.textContent = translated;
+  }
+  const categoryLink = document.querySelector('#category-display a');
+  if (categoryLink) {
+    const slug = categoryLink.getAttribute('href').split('/').pop();
+    categoryLink.href = `/category-he.html?slug=${slug}`;
+  }
+}
+
+window.addEventListener('load', () => {
+  const container = document.getElementById('article-container');
+  if (!container) return;
+  const observer = new MutationObserver(() => {
+    if (container.querySelector('.article-title')) {
+      observer.disconnect();
+      translateArticle();
+    }
+  });
+  observer.observe(container, { childList: true, subtree: true });
+});

--- a/public/js/category.js
+++ b/public/js/category.js
@@ -133,7 +133,9 @@ function loadCategoryArticles(categoryId, categorySlug) {
                 const readingTime = getSafe(() => article.readingTimeMinutes);
                 const articleSlug = getSafe(() => article.slug, '');
                 
-                const articleUrl = `/${categorySlug}/${articleSlug}`;
+                const articleUrl = window.language === 'he'
+                    ? `/article-he.html?slug=${articleSlug}`
+                    : `/${categorySlug}/${articleSlug}`;
 
                 articlesHTML += `
                     <div class="col-md-6 mb-4">

--- a/public/js/index-he.js
+++ b/public/js/index-he.js
@@ -1,54 +1,35 @@
-// Overrides for Hebrew version
+// index-he.js - dynamic Hebrew overrides and translation
 window.language = 'he';
 window.videoKeywords = ['חדשות טכנולוגיה', 'חדשנות', 'סקירות גאדג׳טים'];
 window.podcastQuery = 'פודקאסט טכנולוגיה';
 window.podcastMarket = 'IL';
 
-const hebrewArticles = [
-  {
-    id: 'he1',
-    title: 'בינה מלאכותית בעולם העסקים',
-    excerpt: 'כיצד AI משנה את פני התעשייה.',
-    slug: '#',
-    createdAt: { toDate: () => new Date() },
-    featuredImage: '/img/default-podcast-art.png',
-    readingTimeMinutes: 3,
-    category: 'General'
-  },
-  {
-    id: 'he2',
-    title: 'הגאדג\'ט החדש שמשגע את כולם',
-    excerpt: 'סקירה מהירה של המכשיר החם בשוק.',
-    slug: '#',
-    createdAt: { toDate: () => new Date() },
-    featuredImage: '/img/default-podcast-art.png',
-    readingTimeMinutes: 2,
-    category: 'Gadgets'
-  },
-  {
-    id: 'he3',
-    title: 'מדריך קצר לאבטחת סייבר',
-    excerpt: 'טיפים חשובים לשמירה על פרטיותך.',
-    slug: '#',
-    createdAt: { toDate: () => new Date() },
-    featuredImage: '/img/default-podcast-art.png',
-    readingTimeMinutes: 4,
-    category: 'Security'
+function translateText(text) {
+  return fetch(`https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=he&dt=t&q=${encodeURIComponent(text)}`)
+    .then(r => r.json())
+    .then(d => d[0][0][0])
+    .catch(() => text);
+}
+
+async function translateHome() {
+  const titles = document.querySelectorAll('.article-title');
+  for (const el of titles) {
+    el.textContent = await translateText(el.textContent.trim());
+    const link = el.querySelector('a');
+    if (link && link.href.includes('article.html')) {
+      const url = new URL(link.href);
+      url.pathname = '/article-he.html';
+      link.href = url.toString();
+    }
   }
-];
-
-function loadFeaturedArticle() {
-  const container = document.getElementById('featured-article-container');
-  if (!container) return;
-  const doc = { id: hebrewArticles[0].id, data: () => hebrewArticles[0] };
-  renderArticle(doc, container, true);
+  const descs = document.querySelectorAll('.article-description');
+  for (const el of descs) {
+    if (el.textContent.trim()) {
+      el.textContent = await translateText(el.textContent.trim());
+    }
+  }
 }
 
-function loadLatestArticles() {
-  const container = document.getElementById('articles-container');
-  if (!container) return;
-  container.innerHTML = '';
-  hebrewArticles.slice(0, 3).forEach(article => {
-    container.innerHTML += renderArticleCard(article);
-  });
-}
+document.addEventListener('firebase-ready', () => {
+  setTimeout(translateHome, 3000);
+});

--- a/public/js/index-main.js
+++ b/public/js/index-main.js
@@ -201,7 +201,7 @@ function renderArticle(doc, container, isFeatured = false) {
             }
         }
         
-        const articleUrl = article.slug ? `/article.html?slug=${article.slug}` : '#';
+        const articleUrl = article.slug ? (window.language === 'he' ? `/article-he.html?slug=${article.slug}` : `/article.html?slug=${article.slug}`) : '#';
         const cardClass = isFeatured ? 'featured-article' : 'article-card';
         const titleTag = isFeatured ? 'h2' : 'h3';
         const title = getSafe(() => article.title, 'Untitled Article');
@@ -246,7 +246,7 @@ function renderArticleCard(article) {
             }
         }
         
-        const articleUrl = getSafe(() => article.slug) ? `/article.html?slug=${getSafe(() => article.slug)}` : '#';
+        const articleUrl = getSafe(() => article.slug) ? (window.language === 'he' ? `/article-he.html?slug=${getSafe(() => article.slug)}` : `/article.html?slug=${getSafe(() => article.slug)}`) : '#';
         const title = getSafe(() => article.title, 'Untitled Article');
         const excerpt = getSafe(() => article.excerpt, '');
         const featuredImage = getSafe(() => article.featuredImage);

--- a/public/js/nav-loader.js
+++ b/public/js/nav-loader.js
@@ -205,7 +205,7 @@ function initializeResponsiveCategories() {
       li.setAttribute('data-category', 'true'); // Mark as category item
       const a = document.createElement('a');
       a.className = 'nav-link';
-      a.href = `/${cat.slug}`;
+      a.href = window.language === 'he' ? `/category-he.html?slug=${cat.slug}` : `/${cat.slug}`;
       a.textContent = translateCategory(cat.name);
       li.appendChild(a);
       
@@ -224,7 +224,7 @@ function initializeResponsiveCategories() {
         const li = document.createElement('li');
         const a = document.createElement('a');
         a.className = 'dropdown-item';
-        a.href = `/${cat.slug}`;
+        a.href = window.language === 'he' ? `/category-he.html?slug=${cat.slug}` : `/${cat.slug}`;
         a.textContent = translateCategory(cat.name);
         li.appendChild(a);
         moreDropdownMenu.appendChild(li);
@@ -323,16 +323,17 @@ function loadFooterCategories() {
         snapshot.forEach(doc => {
           const category = doc.data();
           const slug = category.slug || category.name.toLowerCase().replace(/\s+/g, '-');
-          categoriesHTML += `<li><a href="/${slug}">${translateCategory(category.name)}</a></li>`;
+          const href = window.language === 'he' ? `/category-he.html?slug=${slug}` : `/${slug}`;
+          categoriesHTML += `<li><a href="${href}">${translateCategory(category.name)}</a></li>`;
         });
         footerCategoriesList.innerHTML = categoriesHTML;
       } else {
         // Use default categories
         footerCategoriesList.innerHTML = `
-          <li><a href="/ai">${translateCategory('AI')}</a></li>
-          <li><a href="/gadgets">${translateCategory('Gadgets')}</a></li>
-          <li><a href="/startups">${translateCategory('Startups')}</a></li>
-          <li><a href="/crypto">${translateCategory('Crypto')}</a></li>
+          <li><a href="${window.language === 'he' ? '/category-he.html?slug=ai' : '/ai'}">${translateCategory('AI')}</a></li>
+          <li><a href="${window.language === 'he' ? '/category-he.html?slug=gadgets' : '/gadgets'}">${translateCategory('Gadgets')}</a></li>
+          <li><a href="${window.language === 'he' ? '/category-he.html?slug=startups' : '/startups'}">${translateCategory('Startups')}</a></li>
+          <li><a href="${window.language === 'he' ? '/category-he.html?slug=crypto' : '/crypto'}">${translateCategory('Crypto')}</a></li>
         `;
       }
     })

--- a/public/nav-he.html
+++ b/public/nav-he.html
@@ -1,7 +1,7 @@
 <!-- Hebrew version of navigation bar -->
 <nav class="navbar navbar-expand-lg navbar-light bg-white py-3">
   <div class="container">
-    <a class="navbar-brand" href="/index-he.html">טק יומי</a>
+    <a class="navbar-brand" href="/index-he.html">TrendingTech Daily</a>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarMain">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
## Summary
- add Hebrew versions of article and category pages
- translate homepage and articles dynamically with new scripts
- keep site branding as "TrendingTech Daily" in Hebrew UI
- update navigation logic for Hebrew category links

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68853b4fe4bc8333b97df574d8a356a2