### PR TITLE
feat: add GitHub trending section to sidebar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -168,6 +168,15 @@
         </div>
         </div>
 
+<!-- Trending GitHub Section inserted -->
+        <div class="sidebar-section mb-5" id="trending-github-section">
+          <h4>Trending GitHub Repositories</h4>
+          <div id="trending-github-loader" class="text-center py-2">
+            <div class="spinner-border spinner-border-sm" role="status"></div>
+          </div>
+          <ul id="trending-github-list" class="list-group list-group-flush"></ul>
+        </div>
+
         <div class="sidebar-section automation-banner mb-5">
           <a href="https://www.automationbymeir.com/" target="_blank" rel="noopener" class="automation-banner-link">
             <h4 class="mb-2">Automation by Meir</h4>
@@ -262,5 +271,8 @@
       </div>
     </div>
   </div>
+  <!-- Include our new script for trending GitHub repos -->
+  <script src="js/github-trending.js"></script>
+
 </body>
 </html>

--- a/public/js/github-trending.js
+++ b/public/js/github-trending.js
@@ -1,0 +1,70 @@
+// github-trending.js
+// This script fetches trending GitHub repositories created within the last week
+// and displays them in the sidebar section. It uses GitHub's search API to
+// approximate trending repos by sorting new repositories by star count.
+
+document.addEventListener('DOMContentLoaded', () => {
+  const listEl = document.getElementById('trending-github-list');
+  const loaderEl = document.getElementById('trending-github-loader');
+  // Exit if container is not present (e.g., on pages without sidebar)
+  if (!listEl || !loaderEl) return;
+
+  // Compute date string for the last 7 days
+  const daysAgo = 7;
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  const dateString = date.toISOString().split('T')[0];
+
+  // GitHub Search API: fetch top repos created after dateString, sorted by stars
+  const apiUrl = `https://api.github.com/search/repositories?q=created:>${dateString}&sort=stars&order=desc&per_page=5`;
+
+  fetch(apiUrl)
+    .then(response => {
+      // Basic error handling for non-OK responses
+      if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}`);
+      }
+      return response.json();
+    })
+    .then(data => {
+      loaderEl.style.display = 'none';
+      const repos = data.items || [];
+      // Display message if no repos returned
+      if (repos.length === 0) {
+        const noItem = document.createElement('li');
+        noItem.textContent = 'No trending repositories found.';
+        noItem.classList.add('list-group-item');
+        listEl.appendChild(noItem);
+        return;
+      }
+      // Populate list with repos
+      repos.forEach(repo => {
+        const li = document.createElement('li');
+        li.classList.add('list-group-item');
+        // Build inner HTML with repository link, description and star count
+        const description = repo.description ? repo.description.substring(0, 80) : '';
+        li.innerHTML = `
+          <div class="d-flex justify-content-between align-items-start">
+            <div class="flex-grow-1 me-2">
+              <a href="${repo.html_url}" target="_blank" rel="noopener" class="fw-semibold">
+                ${repo.full_name}
+              </a>
+              <p class="small mb-0 text-muted">${description}</p>
+            </div>
+            <span class="badge bg-secondary">★ ${repo.stargazers_count}</span>
+          </div>
+        `;
+        listEl.appendChild(li);
+      });
+    })
+    .catch(error => {
+      // Hide loader and show error message on failure
+      loaderEl.style.display = 'none';
+      const errItem = document.createElement('li');
+      errItem.textContent = 'Error loading trending repositories.';
+      errItem.classList.add('list-group-item');
+      listEl.appendChild(errItem);
+      // Optionally log error to console
+      console.error('Error fetching trending repos:', error);
+    });
+});


### PR DESCRIPTION
## Summary
- add sidebar block showing trending GitHub repositories
- fetch and display top starred repos from the last week

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890fd052c548333ad88d973d016f1f1