### PR TITLE
fix: prevent overflow in trending repo cards

### DIFF
--- a/public/css/trending-github.css
+++ b/public/css/trending-github.css
@@ -1,0 +1,17 @@
+/* Styles for Trending GitHub Repositories in sidebar */
+#trending-github-list .list-group-item {
+  overflow: hidden;
+}
+
+#trending-github-list .repo-info {
+  min-width: 0; /* allow flex item to shrink so text wraps */
+}
+
+#trending-github-list .repo-name {
+  display: block; /* take full width for wrapping */
+  overflow-wrap: anywhere;
+}
+
+#trending-github-list .repo-description {
+  overflow-wrap: anywhere;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,7 @@
   <link rel="stylesheet" href="css/ai-agent.css">
   <link rel="stylesheet" href="css/popup.css" />
   <link rel="stylesheet" href="css/sidebar-podcasts.css" />
+  <link rel="stylesheet" href="css/trending-github.css" />
 
 
 

--- a/public/js/github-trending.js
+++ b/public/js/github-trending.js
@@ -45,13 +45,13 @@ document.addEventListener('DOMContentLoaded', () => {
         const description = repo.description ? repo.description.substring(0, 80) : '';
         li.innerHTML = `
           <div class="d-flex justify-content-between align-items-start">
-            <div class="flex-grow-1 me-2">
-              <a href="${repo.html_url}" target="_blank" rel="noopener" class="fw-semibold">
+            <div class="flex-grow-1 me-2 repo-info">
+              <a href="${repo.html_url}" target="_blank" rel="noopener" class="fw-semibold repo-name">
                 ${repo.full_name}
               </a>
-              <p class="small mb-0 text-muted">${description}</p>
+              <p class="small mb-0 text-muted repo-description">${description}</p>
             </div>
-            <span class="badge bg-secondary">★ ${repo.stargazers_count}</span>
+            <span class="badge bg-secondary flex-shrink-0">★ ${repo.stargazers_count}</span>
           </div>
         `;
         listEl.appendChild(li);


### PR DESCRIPTION
## Summary
- link new stylesheet for GitHub trending list
- wrap long repository names and descriptions to stay within card
- add CSS rules to keep trending repository text inside card

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68935e12865483339bb1b37843e26ace