### PR TITLE
fix: allow cross-origin for top ten article function

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -75,30 +75,37 @@ exports.generateArticleContent = onCall({ secrets: ["GEMINI_API_KEY"], timeoutSe
 exports.rephraseText = onCall({ secrets: ["GEMINI_API_KEY"], region: "us-central1" }, aiCallables.rephraseText);
 exports.suggestArticleTopic = onCall({ secrets: ["GROK_API_KEY"], region: "us-central1" }, aiCallables.suggestArticleTopic);
 exports.generateArticleImage = onCall({ secrets: ["GEMINI_API_KEY", "UNSPLASH_ACCESS_KEY"], region: "us-central1", timeoutSeconds: 60 }, aiCallables.generateArticleImage);
-exports.generateTopTenArticle = onRequest({ secrets: ["GEMINI_API_KEY", "UNSPLASH_ACCESS_KEY"], region: "us-central1", timeoutSeconds: 300 }, async (req, res) => {
-  cors(req, res, async () => {
-    try {
-      const authHeader = req.headers.authorization || "";
-      const match = authHeader.match(/^Bearer (.+)$/);
-      if (!match) {
-        res.status(401).json({ error: "Unauthorized" });
-        return;
-      }
-      let decoded;
-      try {
-        decoded = await admin.auth().verifyIdToken(match[1]);
-      } catch (err) {
-        res.status(401).json({ error: "Unauthorized" });
-        return;
-      }
-      const data = typeof req.body === "object" ? req.body : {};
-      const result = await aiCallables.generateTopTenArticle({ data, auth: { uid: decoded.uid, token: decoded } });
-      res.json(result);
-    } catch (err) {
-      logger.error("generateTopTenArticle HTTP error:", err);
-      res.status(500).json({ error: err.message || "Failed to generate top list article" });
+exports.generateTopTenArticle = onRequest({
+  secrets: ["GEMINI_API_KEY", "UNSPLASH_ACCESS_KEY"],
+  region: "us-central1",
+  timeoutSeconds: 300,
+  cors: ["https://trendingtech-daily.web.app"],
+}, async (req, res) => {
+  if (req.method === "OPTIONS") {
+    res.status(204).send("");
+    return;
+  }
+  try {
+    const authHeader = req.headers.authorization || "";
+    const match = authHeader.match(/^Bearer (.+)$/);
+    if (!match) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
     }
-  });
+    let decoded;
+    try {
+      decoded = await admin.auth().verifyIdToken(match[1]);
+    } catch (err) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    const data = typeof req.body === "object" ? req.body : {};
+    const result = await aiCallables.generateTopTenArticle({ data, auth: { uid: decoded.uid, token: decoded } });
+    res.json(result);
+  } catch (err) {
+    logger.error("generateTopTenArticle HTTP error:", err);
+    res.status(500).json({ error: err.message || "Failed to generate top list article" });
+  }
 });
 exports.getStockDataForCompanies = onCall({ secrets: ["FINNHUB_API_KEY"], region: "us-central1" }, aiCallables.getStockDataForCompanies);
 exports.readArticleAloud = onCall({ secrets: ["GEMINI_API_KEY"], region: "us-central1", timeoutSeconds: 60 }, aiCallables.readArticleAloud);


### PR DESCRIPTION
## Summary
- configure built-in CORS for `generateTopTenArticle` to allow requests from the web app and handle preflight with a 204 response

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4dd9593588333b0b45217ad453550