### PR TITLE
feat: add admin top 10 publish button and richer content

### DIFF
--- a/functions/callable/ai.js
+++ b/functions/callable/ai.js
@@ -424,7 +424,7 @@ async function generateTopTenArticle(request) {
 
 Requirements:
 - Provide a brief introductory paragraph (key: intro).
-- Provide exactly ${count} list items (key: items) where each item has: title, paragraph, imagePrompt, imageAltText.
+- Provide exactly ${count} list items (key: items) where each item has: title, a detailed paragraph of at least 80 words, imagePrompt, imageAltText.
 - Provide a concluding paragraph (key: conclusion).
 - Provide relevant tags (key: tags) and a URL-friendly slug (key: slug).
 Output ONLY JSON with keys: title, slug, intro, items, conclusion, tags.`;
@@ -459,7 +459,7 @@ Output ONLY JSON with keys: title, slug, intro, items, conclusion, tags.`;
         if (parsed.intro) content += `<p>${parsed.intro}</p>`;
         parsed.items.forEach((item, idx) => {
             content += `<h2>${idx + 1}. ${item.title}</h2>`;
-            if (item.imageUrl) content += `<p><img src="${item.imageUrl}" alt="${item.imageAltText || ''}"></p>`;
+            if (item.imageUrl) content += `<p><img src="${item.imageUrl}" alt="${item.imageAltText || ''}" class="img-fluid"></p>`;
             content += `<p>${item.paragraph}</p>`;
         });
         if (parsed.conclusion) content += `<p>${parsed.conclusion}</p>`;

--- a/public/admin/components/articles.js
+++ b/public/admin/components/articles.js
@@ -74,9 +74,14 @@ if (typeof window.articlesManagerInitialized === 'undefined') {
             <div class="section-container">
                 <div class="d-flex justify-content-between align-items-center mb-4">
                     <h3>Manage Articles</h3>
-                    <button id="new-article-btn" class="btn btn-primary">
-                        <i class="bi bi-plus-circle me-2"></i>New Article
-                    </button>
+                    <div>
+                        <button id="top10-article-btn" class="btn btn-outline-secondary me-2">
+                            <i class="bi bi-list-ol me-2"></i>Top 10 Article
+                        </button>
+                        <button id="new-article-btn" class="btn btn-primary">
+                            <i class="bi bi-plus-circle me-2"></i>New Article
+                        </button>
+                    </div>
                 </div>
                 <div class="row mb-3">
                     <div class="col-md-6">
@@ -111,6 +116,16 @@ if (typeof window.articlesManagerInitialized === 'undefined') {
         contentArea.innerHTML = articlesHTML;
 
         document.getElementById('new-article-btn')?.addEventListener('click', () => openArticleEditor());
+
+        document.getElementById('top10-article-btn')?.addEventListener('click', () => {
+            if (typeof loadTop10Generator === 'function') {
+                loadTop10Generator();
+                document.querySelectorAll('#admin-sidebar .nav-link').forEach(l => l.classList.remove('active'));
+                document.querySelector('#admin-sidebar .nav-link[data-section="top10"]')?.classList.add('active');
+            } else {
+                alert('Top 10 generator not available.');
+            }
+        });
 
         const searchInput = document.getElementById('article-search');
         if (searchInput) {

--- a/public/admin/components/top10.js
+++ b/public/admin/components/top10.js
@@ -102,7 +102,13 @@
         } else {
           statusEl.innerHTML = '<div class="text-success">Article generated and saved.</div>';
         }
-        previewEl.innerHTML = data.content;
+        previewEl.innerHTML = `
+          <article>
+            <header class="article-header mb-3">
+              <h1 class="article-title">${data.title}</h1>
+            </header>
+            <div class="article-body-content">${data.content}</div>
+          </article>`;
       } catch(err){
         console.error('Error generating top 10 article', err);
         statusEl.innerHTML = '<div class="text-danger">Failed to generate article.</div>';


### PR DESCRIPTION
## Summary
- add Top 10 Article button in admin articles section to open generator
- request richer paragraphs for each top 10 recommendation and ensure images follow article styling
- preview generated Top 10 articles using standard article layout

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a61ba45f008333b62b6dda8510926e