### PR TITLE
Limit top 10 generator image width

### DIFF
--- a/public/admin/css/admin.css
+++ b/public/admin/css/admin.css
@@ -267,3 +267,12 @@ select {
     max-width: 100%;
     height: auto;
 }
+
+/* Ensure generated article images aren't excessively large */
+.article-body-content img {
+    max-width: 600px;
+    width: 100%;
+    height: auto;
+    display: block;
+    margin: 1rem auto;
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -615,12 +615,21 @@ main > .container > section {
   display: block; 
 }
 
-.article-page-featured-image { 
-  display: block; 
-  width: 100%; 
-  height: auto; 
-  object-fit: cover; 
-  max-height: 60vh; 
+.article-page-featured-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  max-height: 60vh;
+}
+
+/* Ensure inline article images are not overly large */
+.article-body-content img {
+  max-width: 600px;
+  width: 100%;
+  height: auto;
+  display: block;
+  margin: var(--spacing-md) auto;
 }
 
 /* Utility classes */


### PR DESCRIPTION
## Summary
- Restrict inline article images to a max width so generated Top 10 articles show smaller images
- Apply same image sizing in the admin dashboard preview

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a61f36c0ac8333a685ce0a8d5057ca