### PR TITLE
Improve top ten article image relevance

### DIFF
--- a/functions/callable/ai.js
+++ b/functions/callable/ai.js
@@ -443,9 +443,12 @@ Output ONLY JSON with keys: title, slug, intro, items, conclusion, tags. Each it
 
         for (const item of parsed.items) {
             try {
+                const prompt = item.imagePrompt
+                    ? `${item.imagePrompt} ${topic}`
+                    : `${item.title} ${topic} technology`;
                 const imgRes = await generateArticleImage({
                     auth: request.auth,
-                    data: { prompt: item.imagePrompt || `${item.title} illustration`, articleTitle: item.title }
+                    data: { prompt, articleTitle: item.title }
                 });
                 item.imageUrl = imgRes.imageUrl;
                 item.imageAltText = imgRes.imageAltText;

--- a/functions/services/unsplashService.js
+++ b/functions/services/unsplashService.js
@@ -3,7 +3,7 @@ const { logger } = require('../config');
 
 async function fetchImageFromUnsplash(query, accessKey) {
   if (!accessKey) return null;
-  const url = `https://api.unsplash.com/photos/random?orientation=landscape&query=${encodeURIComponent(query)}&client_id=${accessKey}`;
+  const url = `https://api.unsplash.com/search/photos?query=${encodeURIComponent(query)}&orientation=landscape&per_page=1&order_by=relevant&client_id=${accessKey}`;
   try {
     const res = await fetch(url);
     if (!res.ok) {
@@ -12,9 +12,14 @@ async function fetchImageFromUnsplash(query, accessKey) {
       return null;
     }
     const data = await res.json();
+    const photo = data.results && data.results[0];
+    if (!photo) {
+      logger.warn('Unsplash search returned no results for query:', query);
+      return null;
+    }
     return {
-      imageUrl: data.urls && (data.urls.regular || data.urls.full || data.urls.raw),
-      altText: data.alt_description || data.description || query,
+      imageUrl: photo.urls && (photo.urls.regular || photo.urls.full || photo.urls.raw),
+      altText: photo.alt_description || photo.description || query,
     };
   } catch (err) {
     logger.error('Unsplash fetch error:', err);


### PR DESCRIPTION
## Summary
- Expand image prompts in Top 10 article generator with overall topic for more contextual photos.
- Query Unsplash for relevant search results instead of random images.

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` (functions) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68a62b256b108333ad6dc1a909675f29