### PR TITLE
feat: add how-to article generator

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -106,6 +106,35 @@ exports.generateTopTenArticle = onRequest({
   }
 });
 
+exports.generateHowToArticle = onRequest({
+  secrets: ["GEMINI_API_KEY", "UNSPLASH_ACCESS_KEY"],
+  region: "us-central1",
+  timeoutSeconds: 300,
+  cors: ["https://trendingtech-daily.web.app"],
+}, async (req, res) => {
+  try {
+    const authHeader = req.headers.authorization || "";
+    const match = authHeader.match(/^Bearer (.+)$/);
+    if (!match) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    let decoded;
+    try {
+      decoded = await admin.auth().verifyIdToken(match[1]);
+    } catch (err) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    const data = typeof req.body === "object" ? req.body : {};
+    const result = await aiCallables.generateHowToArticle({ data, auth: { uid: decoded.uid, token: decoded } });
+    res.json(result);
+  } catch (err) {
+    logger.error("generateHowToArticle HTTP error:", err);
+    res.status(500).json({ error: err.message || "Failed to generate how-to article" });
+  }
+});
+
 exports.getStockDataForCompanies = onCall({ secrets: ["FINNHUB_API_KEY"], region: "us-central1" }, aiCallables.getStockDataForCompanies);
 exports.readArticleAloud = onCall({ secrets: ["GEMINI_API_KEY"], region: "us-central1", timeoutSeconds: 60 }, aiCallables.readArticleAloud);
 exports.generateAIAgentResponse = onCall({ secrets: ["GEMINI_API_KEY"], region: "us-central1", timeoutSeconds: 120 }, toolCallables.generateAIAgentResponse);

--- a/public/admin/components/howto.js
+++ b/public/admin/components/howto.js
@@ -1,0 +1,120 @@
+(function(){
+  const articlesCollection = db.collection('articles');
+  const sectionsCollection = db.collection('sections');
+
+  class HowToGenerator {
+    async render(containerId){
+      const container = document.getElementById(containerId);
+      if(!container) return;
+      container.innerHTML = this.getHTML();
+      await this.loadCategories();
+      document.getElementById('generate-howto-btn').addEventListener('click', () => this.handleGenerate());
+    }
+
+    getHTML(){
+      return `
+      <div class="section-container">
+        <h3>How-To Article Generator</h3>
+        <div class="mb-3">
+          <label for="howto-topic" class="form-label">Topic</label>
+          <input type="text" id="howto-topic" class="form-control" placeholder="Build a gaming PC" />
+        </div>
+        <div class="mb-3">
+          <label for="howto-category" class="form-label">Category</label>
+          <select id="howto-category" class="form-select"></select>
+        </div>
+        <div class="form-check mb-3">
+          <input class="form-check-input" type="checkbox" id="howto-publish">
+          <label class="form-check-label" for="howto-publish">Publish immediately</label>
+        </div>
+        <button type="button" class="btn btn-primary" id="generate-howto-btn">Generate Article</button>
+        <div id="howto-status" class="mt-3"></div>
+        <div id="howto-preview" class="mt-4"></div>
+      </div>`;
+    }
+
+    async loadCategories(){
+      const select = document.getElementById('howto-category');
+      try {
+        const snap = await sectionsCollection.where('active','==',true).orderBy('name').get();
+        select.innerHTML = snap.docs.map(doc => `<option value="${doc.id}">${doc.data().name}</option>`).join('');
+      } catch(err) {
+        console.error('Error loading categories', err);
+        select.innerHTML = '<option value="">Uncategorized</option>';
+      }
+    }
+
+    estimateReadingTime(html){
+      if(!html) return 0;
+      const temp = document.createElement('div');
+      temp.innerHTML = html;
+      const text = temp.textContent || temp.innerText || '';
+      const words = text.trim().split(/\s+/).filter(Boolean).length;
+      return Math.max(1, Math.ceil(words / 225));
+    }
+
+    async handleGenerate(){
+      const topicInput = document.getElementById('howto-topic');
+      const category = document.getElementById('howto-category').value;
+      const publish = document.getElementById('howto-publish').checked;
+      const statusEl = document.getElementById('howto-status');
+      const previewEl = document.getElementById('howto-preview');
+      const topic = topicInput.value.trim();
+      if(!topic){
+        statusEl.innerHTML = '<div class="text-danger">Please enter a topic.</div>';
+        return;
+      }
+      statusEl.innerHTML = 'Generating article... <span class="spinner-border spinner-border-sm"></span>';
+      previewEl.innerHTML = '';
+      try {
+        const token = await firebase.auth().currentUser.getIdToken();
+        const response = await fetch('https://us-central1-trendingtech-daily.cloudfunctions.net/generateHowToArticle', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+          },
+          body: JSON.stringify({ topic })
+        });
+        if (!response.ok) throw new Error(`Request failed with status ${response.status}`);
+        const data = await response.json();
+        const readingTime = this.estimateReadingTime(data.content);
+        const articleData = {
+          title: data.title,
+          slug: data.slug,
+          content: data.content,
+          excerpt: data.excerpt,
+          tags: data.tags || [],
+          featuredImage: data.steps && data.steps[0] ? data.steps[0].imageUrl : '',
+          imageAltText: data.steps && data.steps[0] ? data.steps[0].imageAltText : '',
+          category,
+          published: publish,
+          readingTimeMinutes: readingTime,
+          createdAt: firebase.firestore.FieldValue.serverTimestamp()
+        };
+        if (publish) {
+          articleData.publishedAt = firebase.firestore.FieldValue.serverTimestamp();
+        }
+        await articlesCollection.add(articleData);
+        if (publish) {
+          const viewUrl = `/${category}/${data.slug}`;
+          statusEl.innerHTML = `<div class="text-success">Article generated and published. <a href="${viewUrl}" target="_blank">View</a></div>`;
+        } else {
+          statusEl.innerHTML = '<div class="text-success">Article generated and saved.</div>';
+        }
+        previewEl.innerHTML = `
+          <article>
+            <header class="article-header mb-3">
+              <h1 class="article-title">${data.title}</h1>
+            </header>
+            <div class="article-body-content">${data.content}</div>
+          </article>`;
+      } catch(err){
+        console.error('Error generating how-to article', err);
+        statusEl.innerHTML = '<div class="text-danger">Failed to generate article.</div>';
+      }
+    }
+  }
+
+  window.HowToGenerator = HowToGenerator;
+})();

--- a/public/admin/components/sidebar.js
+++ b/public/admin/components/sidebar.js
@@ -10,6 +10,9 @@ function initSidebar() {
       <a href="#top10" class="nav-link" data-section="top10">
         <i class="bi bi-list-ol me-2"></i>Top 10 Generator
       </a>
+      <a href="#howto" class="nav-link" data-section="howto">
+        <i class="bi bi-tools me-2"></i>How-To Generator
+      </a>
       <a href="#sections" class="nav-link" data-section="sections">
         <i class="bi bi-grid me-2"></i>Sections
       </a>
@@ -69,6 +72,9 @@ function initSidebar() {
         case "top10":
           loadTop10Generator();
           break;
+        case "howto":
+          loadHowToGenerator();
+          break;
         case "sections":
           loadSectionsManager();
           break;
@@ -117,6 +123,32 @@ function initSidebar() {
         if (window.Top10Generator) {
           const comp = new window.Top10Generator();
           comp.render('top10-generator-container');
+        } else {
+          contentArea.innerHTML = '<div class="alert alert-danger">Failed to load generator.</div>';
+        }
+      };
+      script.onerror = function() {
+        contentArea.innerHTML = '<div class="alert alert-danger">Failed to load generator.</div>';
+      };
+      document.head.appendChild(script);
+    }
+  };
+
+  window.loadHowToGenerator = function() {
+    const contentArea = document.getElementById("content-area");
+    contentArea.innerHTML = '<div id="howto-generator-container" class="section-container text-center p-5">Loading... <span class="spinner-border"></span></div>';
+
+    if (window.HowToGenerator) {
+      const comp = new window.HowToGenerator();
+      comp.render('howto-generator-container');
+    } else {
+      const script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = '/admin/components/howto.js';
+      script.onload = function() {
+        if (window.HowToGenerator) {
+          const comp = new window.HowToGenerator();
+          comp.render('howto-generator-container');
         } else {
           contentArea.innerHTML = '<div class="alert alert-danger">Failed to load generator.</div>';
         }


### PR DESCRIPTION
## Summary
- add admin sidebar option for How-To Generator
- implement HowToGenerator component for creating step-by-step articles
- expose `generateHowToArticle` cloud function to back the new feature

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `(cd functions && npm test)` *(fails: No tests found, exiting with code 1)*
- `(cd functions && npm run lint)`

------
https://chatgpt.com/codex/tasks/task_b_68a9d4cc2da88333a04007cbcf0ca60f