### PR TITLE
fix: enable CORS for how-to article generation

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -110,30 +110,29 @@ exports.generateHowToArticle = onRequest({
   secrets: ["GEMINI_API_KEY", "UNSPLASH_ACCESS_KEY"],
   region: "us-central1",
   timeoutSeconds: 300,
-}, (req, res) => {
-  cors(req, res, async () => {
-    try {
-      const authHeader = req.headers.authorization || "";
-      const match = authHeader.match(/^Bearer (.+)$/);
-      if (!match) {
-        res.status(401).json({ error: "Unauthorized" });
-        return;
-      }
-      let decoded;
-      try {
-        decoded = await admin.auth().verifyIdToken(match[1]);
-      } catch (err) {
-        res.status(401).json({ error: "Unauthorized" });
-        return;
-      }
-      const data = typeof req.body === "object" ? req.body : {};
-      const result = await aiCallables.generateHowToArticle({ data, auth: { uid: decoded.uid, token: decoded } });
-      res.json(result);
-    } catch (err) {
-      logger.error("generateHowToArticle HTTP error:", err);
-      res.status(500).json({ error: err.message || "Failed to generate how-to article" });
+  cors: ["https://trendingtech-daily.web.app"],
+}, async (req, res) => {
+  try {
+    const authHeader = req.headers.authorization || "";
+    const match = authHeader.match(/^Bearer (.+)$/);
+    if (!match) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
     }
-  });
+    let decoded;
+    try {
+      decoded = await admin.auth().verifyIdToken(match[1]);
+    } catch (err) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    const data = typeof req.body === "object" ? req.body : {};
+    const result = await aiCallables.generateHowToArticle({ data, auth: { uid: decoded.uid, token: decoded } });
+    res.json(result);
+  } catch (err) {
+    logger.error("generateHowToArticle HTTP error:", err);
+    res.status(500).json({ error: err.message || "Failed to generate how-to article" });
+  }
 });
 
 exports.getStockDataForCompanies = onCall({ secrets: ["FINNHUB_API_KEY"], region: "us-central1" }, aiCallables.getStockDataForCompanies);


### PR DESCRIPTION
## Summary
- enable CORS for `generateHowToArticle` Cloud Function

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a9d98f1aa88333811acbfdfd605b46