### PR TITLE
fix: keep categories visible in nav bar

### DIFF
--- a/public/js/nav-loader.js
+++ b/public/js/nav-loader.js
@@ -216,6 +216,13 @@ function initializeResponsiveCategories() {
     stockLi.appendChild(stockLink);
     navbarNav.insertBefore(stockLi, insertBeforeElement);
     categoryElements.push({ li: stockLi, cat: stockCat });
+    
+    // If the navbar hasn't been sized yet (e.g., collapsed), skip overflow handling
+    if (navbarNav.clientWidth === 0) {
+      if (moreDropdownMenu) moreDropdownMenu.innerHTML = '';
+      if (moreDropdown) moreDropdown.classList.add('d-none');
+      return;
+    }
 
     // Move overflowing categories into the More dropdown
     const hiddenCategories = [];


### PR DESCRIPTION
## Summary
- avoid running overflow logic when navbar width is zero

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aa066863a88333b92d5b8b2b75cec1