### PR TITLE
Revert clean article URL changes to restore article loading

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -113,11 +113,11 @@
       },
       {
         "source": "/*/*",
-        "destination": "/article.html"
+        "destination": "/router.html"
       },
       {
         "source": "/*",
-        "destination": "/category.html"
+        "destination": "/router.html"
       }
     ],
     "headers": [

--- a/public/js/ai-agent.js
+++ b/public/js/ai-agent.js
@@ -419,8 +419,7 @@ class AITechAgent {
       const pageInfo = { type: 'general', url: window.location.href, title: document.title, articleTitle: null, articleContentSample: null };
       const pathname = window.location.pathname.toLowerCase();
 
-      const segments = pathname.split('/').filter(Boolean);
-      if (pathname.includes('/article.html') || segments.length === 2) {
+      if (pathname.includes('/article.html') || pathname.startsWith('/article/')) {
           pageInfo.type = 'article';
           const titleElement = document.querySelector('h1.article-title, article h1, .td-post-title .entry-title');
           const contentElement = document.querySelector('.article-body-content, .td-post-content, article .entry-content');

--- a/public/js/article-page.js
+++ b/public/js/article-page.js
@@ -384,8 +384,7 @@ async function handlePostRenderActions(article, section) {
         readHistoryRef.set({
             lastReadAt: firebase.firestore.FieldValue.serverTimestamp(),
             articleTitle: getSafe(() => article.title, 'Untitled'),
-            articleSlug: getSafe(() => article.slug, ''),
-            articleCategory: getSafe(() => section?.slug || article.category?.toLowerCase(), '')
+            articleSlug: getSafe(() => article.slug, '')
         }, { merge: true }).catch(err => console.error("Error updating read history:", err));
     }
     
@@ -397,7 +396,7 @@ async function handlePostRenderActions(article, section) {
     
     // Setup save button
     if (currentUser && typeof setupSaveArticleButton === 'function') {
-        setupSaveArticleButton(currentUser, article.id, article, section);
+        setupSaveArticleButton(currentUser, article.id, article);
     }
     
     // Load comments
@@ -407,7 +406,7 @@ async function handlePostRenderActions(article, section) {
     
     // Setup comment form
     if (typeof setupCommentForm === 'function') {
-        setupCommentForm(article, section);
+        setupCommentForm(article);
     }
     
     // Load related articles
@@ -448,7 +447,7 @@ function showError(message) {
 }
 
 // Setup save article button
-async function setupSaveArticleButton(user, articleId, articleData, section) {
+async function setupSaveArticleButton(user, articleId, articleData) {
     const saveBtn = document.getElementById('save-article-btn');
     if (!saveBtn || !user || !articleId || !db) {
         if (saveBtn) saveBtn.style.display = 'none';
@@ -483,8 +482,7 @@ async function setupSaveArticleButton(user, articleId, articleData, section) {
                 await savedDocRef.set({
                     savedAt: firebase.firestore.FieldValue.serverTimestamp(),
                     articleTitle: getSafe(() => articleData.title, 'Untitled'),
-                    articleSlug: getSafe(() => articleData.slug, ''),
-                    articleCategory: getSafe(() => section?.slug || articleData.category?.toLowerCase(), '')
+                    articleSlug: getSafe(() => articleData.slug, '')
                 });
                 isCurrentlySaved = true;
             }
@@ -520,7 +518,7 @@ function updateSaveButtonUI(isSaved) {
 }
 
 // Setup comment form
-function setupCommentForm(article, section) {
+function setupCommentForm(article) {
     const commentFormContainer = document.getElementById('comment-form-container');
     const commentLoginPrompt = document.getElementById('comment-login-prompt');
     const commentForm = document.getElementById('comment-form');
@@ -534,8 +532,7 @@ function setupCommentForm(article, section) {
             // Clone to remove existing listeners
             const newForm = commentForm.cloneNode(true);
             commentForm.parentNode.replaceChild(newForm, commentForm);
-            const categorySlug = section ? section.slug : null;
-            newForm.addEventListener('submit', (e) => handleCommentSubmit(e, article.id, article.slug, article.title, categorySlug, user));
+            newForm.addEventListener('submit', (e) => handleCommentSubmit(e, article.id, article.slug, article.title, user));
         }
     } else {
         if (commentFormContainer) commentFormContainer.style.display = 'none';
@@ -544,7 +541,7 @@ function setupCommentForm(article, section) {
 }
 
 // Handle comment submission
-async function handleCommentSubmit(event, articleId, articleSlug, articleTitle, categorySlug, user) {
+async function handleCommentSubmit(event, articleId, articleSlug, articleTitle, user) {
     event.preventDefault();
     
     if (!user || !db) {
@@ -582,8 +579,7 @@ async function handleCommentSubmit(event, articleId, articleSlug, articleTitle, 
             timestamp: firebase.firestore.FieldValue.serverTimestamp(),
             articleId: articleId,
             articleSlug: articleSlug || '',
-            articleTitle: articleTitle || '',
-            articleCategory: categorySlug || ''
+            articleTitle: articleTitle || ''
         };
         
         await db.collection('articles').doc(articleId).collection('comments').add(commentData);

--- a/public/js/index-main.js
+++ b/public/js/index-main.js
@@ -160,11 +160,7 @@ function loadLatestArticles() {
             let featuredSlug = null;
             const featuredLink = document.querySelector('#featured-article-container .article-title a');
             if (featuredLink?.href) {
-                try {
-                    // Extract slug from path /category/slug
-                    featuredSlug = new URL(featuredLink.href).pathname.split('/')
-                        .filter(Boolean).pop();
-                }
+                try { featuredSlug = new URLSearchParams(new URL(featuredLink.href).search).get('slug'); } 
                 catch(e) { console.warn("Could not parse featured slug"); }
             }
 
@@ -195,20 +191,17 @@ function renderArticle(doc, container, isFeatured = false) {
         const article = { id: doc.id, ...doc.data() };
         const date = getSafe(() => new Date(article.createdAt.toDate()).toLocaleDateString(), 'N/A');
         
-        // Get category info from cache
+        // Get category name from cache with better fallback handling
         let categoryName = 'Uncategorized';
-        let categorySlug = 'uncategorized';
         if (article.category && categoryCache[article.category]) {
             if (typeof categoryCache[article.category] === 'object') {
                 categoryName = categoryCache[article.category].name || 'Uncategorized';
-                categorySlug = categoryCache[article.category].slug || article.category.toLowerCase();
             } else {
                 categoryName = categoryCache[article.category];
-                categorySlug = article.category.toLowerCase();
             }
         }
-
-        const articleUrl = article.slug ? (window.language === 'he' ? `/article-he.html?slug=${article.slug}` : `/${categorySlug}/${article.slug}`) : '#';
+        
+        const articleUrl = article.slug ? (window.language === 'he' ? `/article-he.html?slug=${article.slug}` : `/article.html?slug=${article.slug}`) : '#';
         const cardClass = isFeatured ? 'featured-article' : 'article-card';
         const titleTag = isFeatured ? 'h2' : 'h3';
         const title = getSafe(() => article.title, 'Untitled Article');
@@ -243,20 +236,17 @@ function renderArticleCard(article) {
     try {
         const date = getSafe(() => new Date(article.createdAt.toDate()).toLocaleDateString(), 'N/A');
         
-        // Get category info from cache with better fallback handling
+        // Get category name from cache with better fallback handling
         let categoryName = 'Uncategorized';
-        let categorySlug = 'uncategorized';
         if (article.category && categoryCache[article.category]) {
             if (typeof categoryCache[article.category] === 'object') {
                 categoryName = categoryCache[article.category].name || 'Uncategorized';
-                categorySlug = categoryCache[article.category].slug || article.category.toLowerCase();
             } else {
                 categoryName = categoryCache[article.category];
-                categorySlug = article.category.toLowerCase();
             }
         }
-
-        const articleUrl = getSafe(() => article.slug) ? (window.language === 'he' ? `/article-he.html?slug=${getSafe(() => article.slug)}` : `/${categorySlug}/${getSafe(() => article.slug)}`) : '#';
+        
+        const articleUrl = getSafe(() => article.slug) ? (window.language === 'he' ? `/article-he.html?slug=${getSafe(() => article.slug)}` : `/article.html?slug=${getSafe(() => article.slug)}`) : '#';
         const title = getSafe(() => article.title, 'Untitled Article');
         const excerpt = getSafe(() => article.excerpt, '');
         const featuredImage = getSafe(() => article.featuredImage);

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -470,8 +470,7 @@ async function loadSavedArticles(user) {
             const data = doc.data();
             const title = data.articleTitle || 'Untitled Article';
             const slug = data.articleSlug || '#';
-            const category = data.articleCategory || '';
-            const url = slug !== '#' ? (category ? `/${category}/${slug}` : `/article.html?slug=${slug}`) : '#';
+            const url = slug !== '#' ? `/article.html?slug=${slug}` : '#';
             const date = data.savedAt?.toDate ? new Date(data.savedAt.toDate()).toLocaleDateString() : 'N/A';
             articlesHTML += `
                 <li class="list-group-item d-flex justify-content-between align-items-center">
@@ -507,8 +506,7 @@ async function loadReadHistory(user) {
             const data = doc.data();
             const title = data.articleTitle || 'Untitled Article';
             const slug = data.articleSlug || '#';
-            const category = data.articleCategory || '';
-            const url = slug !== '#' ? (category ? `/${category}/${slug}` : `/article.html?slug=${slug}`) : '#';
+            const url = slug !== '#' ? `/article.html?slug=${slug}` : '#';
             const date = data.lastReadAt?.toDate ? new Date(data.lastReadAt.toDate()).toLocaleString() : 'N/A';
             historyHTML += `
                 <li class="list-group-item d-flex justify-content-between align-items-center">
@@ -549,8 +547,7 @@ async function loadMyComments(user) {
             const date = data.timestamp?.toDate ? new Date(data.timestamp.toDate()).toLocaleDateString() : 'N/A';
             const articleTitle = data.articleTitle || 'Article';
             const articleSlug = data.articleSlug || '#';
-            const category = data.articleCategory || '';
-            const articleUrl = articleSlug !== '#' ? (category ? `/${category}/${articleSlug}#comment-${doc.id}` : `/article.html?slug=${articleSlug}#comment-${doc.id}`) : '#';
+            const articleUrl = articleSlug !== '#' ? `/article.html?slug=${articleSlug}#comment-${doc.id}` : '#';
             commentsHTML += `
                 <li class="list-group-item">
                     <p class="mb-1 fst-italic">"${escapeHtml(text)}"</p>

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -148,17 +148,14 @@ document.addEventListener('DOMContentLoaded', function() {
         (article.excerpt || stripHtml(article.content).substring(0, 150) + '...') : 
         'No preview available';
       
-      const categorySlug = window.categorySlugCache ? (window.categorySlugCache[article.category] || (article.category || '').toLowerCase()) : (article.category || '').toLowerCase();
-      const link = categorySlug ? `/${categorySlug}/${article.slug}` : `/article.html?slug=${article.slug}`;
-
       const articleCard = `
         <article class="search-article-card">
-          <img src="${article.featuredImage || 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cmVjdCB3aWR0aD0iNDAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2Y4ZjlmYSIvPgogIDx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTgiIGZpbGw9IiM2Yzc1N2QiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGRvbWluYW50LWJhc2VsaW5lPSJtaWRkbGUiPk5vIEltYWdlIEF2YWlsYWJsZTwvdGV4dD4KPC9zdmc+'}"
-               alt="${article.title}"
+          <img src="${article.featuredImage || 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cmVjdCB3aWR0aD0iNDAwIiBoZWlnaHQ9IjIwMCIgZmlsbD0iI2Y4ZjlmYSIvPgogIDx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBmb250LWZhbWlseT0iQXJpYWwsIHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTgiIGZpbGw9IiM2Yzc1N2QiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGRvbWluYW50LWJhc2VsaW5lPSJtaWRkbGUiPk5vIEltYWdlIEF2YWlsYWJsZTwvdGV4dD4KPC9zdmc+'}" 
+               alt="${article.title}" 
                class="search-article-image">
           <div class="search-article-content">
             <h2 class="article-title">
-              <a href="${link}">${article.title}</a>
+              <a href="/article/${article.slug}">${article.title}</a>
             </h2>
             <p class="article-description">${excerpt}</p>
             <div class="article-meta">
@@ -316,9 +313,7 @@ document.addEventListener('DOMContentLoaded', function() {
       trendingTopicsList.innerHTML = '';
       snapshot.forEach(doc => {
         const article = doc.data();
-        const categorySlug = window.categorySlugCache ? (window.categorySlugCache[article.category] || (article.category || '').toLowerCase()) : (article.category || '').toLowerCase();
-        const link = categorySlug ? `/${categorySlug}/${article.slug}` : `/article.html?slug=${article.slug}`;
-        const listItem = `<li><a href="${link}">${article.title}</a></li>`;
+        const listItem = `<li><a href="/article/${article.slug}">${article.title}</a></li>`;
         trendingTopicsList.innerHTML += listItem;
       });
         

--- a/public/search.html
+++ b/public/search.html
@@ -142,7 +142,6 @@
   
   // Category name mapping - will be populated from database
   let categoryNames = {};
-  let categorySlugs = {};
   
   let currentResults = [];
   let currentQuery = '';
@@ -172,10 +171,8 @@
           const data = doc.data();
           const categoryId = doc.id;
           const categoryName = data.name || categoryId;
-          const categorySlug = data.slug || categoryId;
 
           categoryNames[categoryId] = categoryName;
-          categorySlugs[categoryId] = categorySlug;
 
           const option = document.createElement('option');
           option.value = categoryId;
@@ -277,9 +274,7 @@
       // Get category display name
       const categoryId = article.category || article.categoryName || '';
       const categoryDisplay = categoryNames[categoryId] || categoryId || 'Uncategorized';
-      const categorySlug = categorySlugs[categoryId] || categoryId;
-      const link = categorySlug ? `/${categorySlug}/${article.slug}` : `/article.html?slug=${article.slug}`;
-
+      
       const articleCard = `
         <div class="article-card mb-3">
           <div class="row g-0">
@@ -291,7 +286,7 @@
             <div class="col-md-8">
               <div class="article-content">
                 <h2 class="article-title">
-                  <a href="${link}">${article.title}</a>
+                  <a href="/article/${article.slug}">${article.title}</a>
                 </h2>
                 <p class="article-description">${excerpt}</p>
                 <div class="article-meta">
@@ -422,17 +417,13 @@
         trendingTopicsList.innerHTML = '';
         altSnapshot.forEach(doc => {
           const article = doc.data();
-          const categorySlug = categorySlugs[article.category] || article.category;
-          const link = categorySlug ? `/${categorySlug}/${article.slug}` : `/article.html?slug=${article.slug}`;
-          trendingTopicsList.innerHTML += `<li><a href="${link}">${article.title}</a></li>`;
+          trendingTopicsList.innerHTML += `<li><a href="/article/${article.slug}">${article.title}</a></li>`;
         });
       } else {
         trendingTopicsList.innerHTML = '';
         snapshot.forEach(doc => {
           const article = doc.data();
-          const categorySlug2 = categorySlugs[article.category] || article.category;
-          const link2 = categorySlug2 ? `/${categorySlug2}/${article.slug}` : `/article.html?slug=${article.slug}`;
-          trendingTopicsList.innerHTML += `<li><a href="${link2}">${article.title}</a></li>`;
+          trendingTopicsList.innerHTML += `<li><a href="/article/${article.slug}">${article.title}</a></li>`;
         });
       }
 
@@ -449,9 +440,7 @@
           trendingTopicsList.innerHTML = '';
           fallbackSnapshot.forEach(doc => {
             const article = doc.data();
-            const categorySlug3 = categorySlugs[article.category] || article.category;
-            const link3 = categorySlug3 ? `/${categorySlug3}/${article.slug}` : `/article.html?slug=${article.slug}`;
-            trendingTopicsList.innerHTML += `<li><a href="${link3}">${article.title}</a></li>`;
+            trendingTopicsList.innerHTML += `<li><a href="/article/${article.slug}">${article.title}</a></li>`;
           });
         } else {
           trendingTopicsList.innerHTML = '<li class="text-muted">No articles found</li>';


### PR DESCRIPTION
## Summary
- revert clean article URL update so links use `article.html?slug` again
- restore Firebase rewrites for legacy article and category routes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aadfc0a7d08333835e59ec926f07c4