### PR TITLE
Fix navbar category initialization across pages

### DIFF
--- a/public/js/app-base.js
+++ b/public/js/app-base.js
@@ -63,7 +63,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 placeholder.innerHTML = html;
                 console.log("Navbar HTML successfully injected.");
 
-                setupAuthListener(); 
+                // Activate navigation enhancements such as dynamic categories
+                if (typeof initializeNavigation === 'function') {
+                    initializeNavigation();
+                }
+
+                setupAuthListener();
 
                 const path = window.location.pathname;
                 document.querySelectorAll('#navbar-placeholder .nav-link').forEach(link => {
@@ -618,7 +623,12 @@ function loadNavbarAndDependentContent() {
             placeholder.innerHTML = html;
             console.log("Navbar HTML successfully injected.");
 
-            setupAuthListener(); 
+            // Ensure nav functions like category rendering are initialized
+            if (typeof initializeNavigation === 'function') {
+                initializeNavigation();
+            }
+
+            setupAuthListener();
 
             // Fixed URL construction - handle relative URLs properly
             const path = window.location.pathname;

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -23,6 +23,11 @@ async function loadNavbar() {
             }
             navbarPlaceholder.innerHTML = navbarHTML;
             console.log("login.js - loadNavbar: Navbar HTML successfully injected.");
+
+            // Initialize navigation features (search, categories, auth) after injecting the navbar
+            if (typeof initializeNavigation === 'function') {
+                initializeNavigation();
+            }
         } catch (error) {
             console.error("login.js - loadNavbar: Error loading navbar:", error);
             navbarPlaceholder.innerHTML = `<p style="text-align:center; padding: 1rem; color: red;">Navbar could not be loaded. Error: ${error.message}.</p>`;

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -23,6 +23,12 @@ async function loadNavbar() {
             }
             navbarPlaceholder.innerHTML = navbarHTML;
             console.log("profile.js - loadNavbar: Navbar HTML successfully injected.");
+
+            // Initialize navigation components like category links
+            if (typeof initializeNavigation === 'function') {
+                initializeNavigation();
+            }
+
             // After navbar is loaded, update its state based on current auth
             // Ensure currentUser is available or fetched if app-base.js doesn't set it globally directly
              if (typeof auth !== 'undefined' && auth.currentUser) {

--- a/public/js/signup-scripts.js
+++ b/public/js/signup-scripts.js
@@ -24,6 +24,11 @@ async function loadNavbar() {
             }
             navbarPlaceholder.innerHTML = navbarHTML;
             console.log("loadNavbar: Navbar HTML successfully injected into #navbar-placeholder.");
+
+            // Initialize navigation enhancements like categories and search
+            if (typeof initializeNavigation === 'function') {
+                initializeNavigation();
+            }
         } catch (error) {
             console.error("loadNavbar: Error loading navbar:", error);
             navbarPlaceholder.innerHTML = `<p class="critical-error-message" style="text-align:center; padding: 1rem;">Navbar could not be loaded. Error: ${error.message}. Path: /nav.html</p>`;


### PR DESCRIPTION
## Summary
- Call `initializeNavigation` after injecting navbar HTML on login, signup, profile, and base scripts to populate dynamic categories and search.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aae1d41e8c83338f39324d113f3c82