### PR TITLE
fix: stabilize navbar categories

### DIFF
--- a/public/js/app-base.js
+++ b/public/js/app-base.js
@@ -246,57 +246,44 @@ function loadLatestArticles(containerId = 'latest-articles') {
 
 // Updated loadSections function for app-base.js that stores full section data
 function loadSections() {
-  const categoryNavPlaceholder = document.getElementById('category-nav-placeholder');
   const footerCategoriesList = document.getElementById('footer-categories-list');
   const sidebarContainer = document.getElementById('categories-list');
-  
+
   // Return the promise chain
   return db.collection('sections').where('active', '==', true).orderBy('order').limit(10).get()
     .then(snap => {
-        let navHTML = '';
         let footerCategoriesHTML = '';
         let sideHTML = '';
         let apiSections = [];
-        
+
         if (!snap.empty) {
             snap.forEach(doc => {
                 const section = { id: doc.id, ...doc.data() };
                 // Use clean URL structure
                 const url = `/${getSafe(() => section.slug, '#')}`;
                 const name = getSafe(() => section.name, 'Unnamed Section');
-                
-                console.log(`Creating nav link for ${name}: ${url}`);
-                
-                navHTML += `<li class="nav-item"><a class="nav-link" href="${url}">${name}</a></li>`;
+
+                console.log(`Processing section for ${name}: ${url}`);
+
                 footerCategoriesHTML += `<li><a href="${url}">${name}</a></li>`;
                 if (sidebarContainer) sideHTML += `<li><a href="${url}">${name}</a></li>`;
-                
+
                 // Store full section data in categoryCache
                 categoryCache[doc.id] = {
                     name: name,
                     slug: section.slug
                 };
-                
+
                 if (section.api) apiSections.push(section);
             });
         }
-        
+
         // Add stock data link
         const stockDataUrl = '/stock-data';
         const stockDataLinkText = 'Stock Data';
-        navHTML += `<li class="nav-item"><a class="nav-link" href="${stockDataUrl}">${stockDataLinkText}</a></li>`;
         footerCategoriesHTML += `<li><a href="${stockDataUrl}">${stockDataLinkText}</a></li>`;
         if (sidebarContainer) sideHTML += `<li><a href="${stockDataUrl}">${stockDataLinkText}</a></li>`;
 
-        if (categoryNavPlaceholder && navHTML) {
-            const fragment = document.createDocumentFragment();
-            const tempDiv = document.createElement('div');
-            tempDiv.innerHTML = navHTML;
-            while (tempDiv.firstChild) {
-                fragment.appendChild(tempDiv.firstChild);
-            }
-            categoryNavPlaceholder.parentNode.insertBefore(fragment, categoryNavPlaceholder);
-        }
         if (footerCategoriesList) footerCategoriesList.innerHTML = footerCategoriesHTML || '<li>No categories found.</li>';
         if (sidebarContainer) sidebarContainer.innerHTML = sideHTML || '<li>No categories found.</li>';
         

--- a/public/js/nav-loader.js
+++ b/public/js/nav-loader.js
@@ -1,9 +1,13 @@
 // js/nav-loader.js - Updated with proper category loading
 
+let firebaseReadyFired = false;
+let navigationInitialized = false; // Track initialization state
+
 /**
  * The main function to initialize the entire navigation system.
  */
 function initializeNavigation() {
+  navigationInitialized = true; // Prevent duplicate initialization calls
   const loadHTML = (url, placeholderId, callback) => {
     fetch(url)
       .then(response => {
@@ -26,12 +30,9 @@ function initializeNavigation() {
   const navFile = '/nav.html';
 
   if (navAlreadyLoaded) {
-    // If the navbar is already present, re-run interactive helpers only
+    // Navbar already exists; ensure helpers and categories are initialized
     initializeSearch();
-    if (!document.getElementById('more-dropdown') ||
-        document.getElementById('category-nav-placeholder')?.previousElementSibling?.id === 'more-dropdown') {
-      initializeResponsiveCategories();
-    }
+    initializeResponsiveCategories();
     if (window.initializeAuth) {
       window.initializeAuth();
     }
@@ -354,36 +355,26 @@ function loadFooterCategories() {
 
 // Wait for Firebase to be ready
 document.addEventListener('firebase-ready', () => {
+  firebaseReadyFired = true;
+  console.log('Firebase ready event fired');
   if (!navigationInitialized) {
-    navigationInitialized = true;
     initializeNavigation();
   }
 });
 
 // Fallback initialization methods
-let firebaseReadyFired = false;
-let navigationInitialized = false; // Track if navigation is already initialized
-
-document.addEventListener('firebase-ready', () => { 
-  firebaseReadyFired = true; 
-  console.log('Firebase ready event fired');
-});
-
-// If the page is using inline Firebase initialization (like stock-data.html)
 document.addEventListener('DOMContentLoaded', () => {
   // Check if Firebase is already initialized after a delay
   setTimeout(() => {
     if (!navigationInitialized && !firebaseReadyFired && typeof firebase !== 'undefined' && firebase.apps && firebase.apps.length > 0) {
       console.log('Fallback: Initializing navigation without firebase-ready event');
-      navigationInitialized = true;
       initializeNavigation();
     }
   }, 1000);
-  
+
   // Also check immediately for pages that initialize Firebase synchronously
   if (!navigationInitialized && typeof firebase !== 'undefined' && firebase.apps && firebase.apps.length > 0) {
     console.log('Firebase already initialized, loading navigation immediately');
-    navigationInitialized = true;
     initializeNavigation();
   }
 });


### PR DESCRIPTION
## Summary
- ensure navigation initialization occurs once and always renders category links
- streamline section loading to avoid interfering with navbar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aae37a9cc48333bde7d8349683973d