### PR TITLE
feat: redirect legacy article URLs

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -113,11 +113,11 @@
       },
       {
         "source": "/*/*",
-        "destination": "/router.html"
+        "function": "handleLegacyRedirects"
       },
       {
         "source": "/*",
-        "destination": "/router.html"
+        "function": "handleDynamicRouting"
       }
     ],
     "headers": [


### PR DESCRIPTION
## Summary
- redirect legacy `/:id/:slug` article URLs to the new `/category/slug` format
- serve category routes through Cloud Functions for dynamic handling

## Testing
- `npm --prefix functions run lint`
- `npm --prefix functions test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_b_68ab544da4008333b471db24d235b161