### PR TITLE
Verify article existence before routing

### DIFF
--- a/functions/http/routing.js
+++ b/functions/http/routing.js
@@ -1,4 +1,6 @@
 const { logger } = require("../config");
+const path = require("path");
+const notFoundPath = path.join(__dirname, '../../public/404.html');
 
 /**
  * Sanitizes and validates a URL slug
@@ -13,9 +15,9 @@ function isValidSlug(slug) {
   const slugRegex = /^[a-z0-9-]+$/i;
   
   // Additional validation
-  return slugRegex.test(slug) && 
-         slug.length <= 100 && 
-         slug.length >= 3 &&
+  return slugRegex.test(slug) &&
+         slug.length <= 100 &&
+         slug.length >= 2 &&
          !slug.startsWith('-') &&  // Don't start with hyphen
          !slug.endsWith('-');      // Don't end with hyphen
 }
@@ -41,7 +43,30 @@ exports.handleArticleRouting = async (req, res) => {
       }
       
       logger.info("Valid article route detected:", { categorySlug, articleSlug });
-      
+
+      // Verify article exists before redirecting
+      const { db } = require("../config");
+      const articleSnapshot = await db.collection("articles")
+        .where("slug", "==", articleSlug)
+        .where("published", "==", true)
+        .limit(1)
+        .get();
+
+      if (articleSnapshot.empty) {
+        logger.info(`No published article found for slug: ${articleSlug}`);
+        return res.status(404).sendFile(notFoundPath);
+      }
+
+      const article = articleSnapshot.docs[0].data();
+      const categoryDoc = await db.collection("sections").doc(article.category).get();
+      const categoryData = categoryDoc.exists ? categoryDoc.data() : null;
+      const categorySlugFromDb = categoryData ? (categoryData.slug || article.category.toLowerCase()) : null;
+
+      if (categorySlugFromDb !== categorySlug) {
+        logger.info(`Article slug ${articleSlug} does not belong to category ${categorySlug}`);
+        return res.status(404).sendFile(notFoundPath);
+      }
+
       // Return HTML that passes routing info to the client
       const articleHtml = `<!DOCTYPE html>
 <html>
@@ -64,7 +89,7 @@ exports.handleArticleRouting = async (req, res) => {
     <p>If you are not redirected, <a href="/article.html">click here</a>.</p>
 </body>
 </html>`;
-      
+
       res.status(200).send(articleHtml);
     } 
     // Check if this is a single-segment path (category)

--- a/public/js/article-page.js
+++ b/public/js/article-page.js
@@ -10,6 +10,17 @@ function getSafe(fn, defaultValue = '') {
     }
 }
 
+// Add noindex meta tag
+function addNoindexMeta() {
+    let meta = document.querySelector('meta[name="robots"]');
+    if (!meta) {
+        meta = document.createElement('meta');
+        meta.setAttribute('name', 'robots');
+        document.head.appendChild(meta);
+    }
+    meta.setAttribute('content', 'noindex');
+}
+
 // Get article info from URL or sessionStorage
 function getArticleInfoFromUrl() {
     // First check if we have server-injected info
@@ -78,8 +89,8 @@ async function loadArticle(articleInfo) {
 
     if (!articleInfo || !articleInfo.articleSlug) {
         console.error('No article slug found in URL');
-        showError('Article not found.');
-        document.title = "Article Not Found | TrendingTechDaily";
+        addNoindexMeta();
+        window.location.replace('/404.html');
         return;
     }
 
@@ -95,8 +106,8 @@ async function loadArticle(articleInfo) {
 
         if (snapshot.empty) {
             console.error('Article not found in database');
-            showError('Article not found or is not published.');
-            document.title = "Article Not Found | TrendingTechDaily";
+            addNoindexMeta();
+            window.location.replace('/404.html');
             return;
         }
 
@@ -146,6 +157,7 @@ async function loadArticle(articleInfo) {
 
     } catch (error) {
         console.error('Error loading article:', error);
+        addNoindexMeta();
         showError(`Failed to load the article. Please try again later.`);
         document.title = "Error | TrendingTechDaily";
     }


### PR DESCRIPTION
## Summary
- Validate article slug on server: check Firestore for published article within correct category before redirecting to `article.html`.
- Add client-side safeguards to redirect missing articles to `/404.html` and mark such pages `noindex`.
- Allow two-character slugs in server routing to fix 404s on short category paths.
- Serve custom 404 page from an absolute path to prevent 500 errors when missing articles are requested.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `(cd functions && npm test)` *(fails: No tests found, exiting with code 1)*
- `firebase deploy --only functions,hosting` *(fails: command not found: firebase)*

------
https://chatgpt.com/codex/tasks/task_b_68ab544b8438833383ca6c055b8caae8