### PR TITLE
Improve SEO routing and metadata

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,10 +1,21 @@
 {
   "hosting": {
     "public": "public",
+    "trailingSlash": false,
     "ignore": [
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "redirects": [
+      { "source": "/about.html", "destination": "/about", "type": 301 },
+      { "source": "/privacy.html", "destination": "/privacy", "type": 301 },
+      { "source": "/terms.html", "destination": "/terms", "type": 301 },
+      { "source": "/login.html", "destination": "/login", "type": 301 },
+      { "source": "/signup.html", "destination": "/signup", "type": 301 },
+      { "source": "/stock-data.html", "destination": "/stock-data", "type": 301 },
+      { "source": "/podcasts.html", "destination": "/podcasts", "type": 301 },
+      { "source": "/forgot-password.html", "destination": "/forgot-password", "type": 301 }
     ],
     "rewrites": [
       {
@@ -36,89 +47,43 @@
         "destination": "/admin/index.html"
       },
       {
-        "source": "/about.html",
-        "destination": "/about.html"
-      },
-      {
         "source": "/about",
         "destination": "/about.html"
-      },
-      {
-        "source": "/privacy.html",
-        "destination": "/privacy.html"
       },
       {
         "source": "/privacy",
         "destination": "/privacy.html"
       },
       {
-        "source": "/terms.html",
-        "destination": "/terms.html"
-      },
-      {
         "source": "/terms",
         "destination": "/terms.html"
-      },
-      {
-        "source": "/login.html",
-        "destination": "/login.html"
       },
       {
         "source": "/login",
         "destination": "/login.html"
       },
       {
-        "source": "/signup.html",
-        "destination": "/signup.html"
-      },
-      {
         "source": "/signup",
         "destination": "/signup.html"
-      },
-      {
-        "source": "/stock-data.html",
-        "destination": "/stock-data.html"
       },
       {
         "source": "/stock-data",
         "destination": "/stock-data.html"
       },
       {
-        "source": "/podcasts.html",
+        "source": "/podcasts",
         "destination": "/podcasts.html"
       },
       {
-        "source": "/podcasts",
-        "destination": "/podcasts.html"
+        "source": "/forgot-password",
+        "destination": "/forgot-password.html"
       },
       {
         "source": "/",
         "destination": "/index.html"
       },
-      {
-        "source": "/js/**",
-        "destination": "/js/**"
-      },
-      {
-        "source": "/css/**",
-        "destination": "/css/**"
-      },
-      {
-        "source": "/img/**",
-        "destination": "/img/**"
-      },
-      {
-        "source": "/json/**",
-        "destination": "/json/**"
-      },
-      {
-        "source": "/*/*",
-        "destination": "/router.html"
-      },
-      {
-        "source": "/*",
-        "destination": "/router.html"
-      }
+      { "source": "/:category/:article", "function": "handleArticleRouting" },
+      { "source": "/:category", "function": "handleArticleRouting" }
     ],
     "headers": [
       {

--- a/public/404.html
+++ b/public/404.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Page Not Found | TrendingTech Daily</title>
     <meta name="description" content="The page you are looking for doesn't exist. Explore trending tech news, search the site, or contact us for help." />
+    <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://trendingtechdaily.com/404.html" />
     <script type="application/ld+json">
     {

--- a/public/about.html
+++ b/public/about.html
@@ -24,6 +24,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Learn more about TrendingTech Daily">
   <title>About - TrendingTech Daily</title>
+  <link rel="canonical" href="https://trendingtechdaily.com/about" />
   
   <!-- Google Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;700;900&family=Source+Serif+Pro:wght@400;600;700&display=swap" rel="stylesheet">

--- a/public/forgot-password.html
+++ b/public/forgot-password.html
@@ -15,7 +15,7 @@
   <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
 <!-- Add this in your <head> section -->
 
-  <link rel="canonical" href="https://trendingtechdaily.com/" />
+  <link rel="canonical" href="https://trendingtechdaily.com/forgot-password" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=IBM+Plex+Sans:wght@400;600&family=Fira+Code&display=swap" rel="stylesheet">

--- a/public/login.html
+++ b/public/login.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login - TrendingTech Daily</title>
+    <link rel="canonical" href="https://trendingtechdaily.com/login" />
 
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/public/podcasts.html
+++ b/public/podcasts.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Recommended Tech Podcasts - TrendingTech Daily</title>
+    <link rel="canonical" href="https://trendingtechdaily.com/podcasts" />
     
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -14,6 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Privacy Policy for TrendingTech Daily">
   <title>Privacy Policy - TrendingTech Daily</title>
+  <link rel="canonical" href="https://trendingtechdaily.com/privacy" />
   
   <!-- Google Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=IBM+Plex+Sans:wght@400;600&family=Fira+Code&display=swap" rel="stylesheet">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
-Allow: /
+Disallow:
 
 Sitemap: https://trendingtechdaily.com/sitemap.xml

--- a/public/signup.html
+++ b/public/signup.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sign Up - TrendingTech Daily</title>
+    <link rel="canonical" href="https://trendingtechdaily.com/signup" />
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/public/stock-data.html
+++ b/public/stock-data.html
@@ -9,6 +9,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Stock Market Data - TrendingTech Daily</title>
+    <link rel="canonical" href="https://trendingtechdaily.com/stock-data" />
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />

--- a/public/terms.html
+++ b/public/terms.html
@@ -14,6 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Terms of Use for TrendingTech Daily">
   <title>Terms of Use - TrendingTech Daily</title>
+  <link rel="canonical" href="https://trendingtechdaily.com/terms" />
   
   <!-- Google Fonts -->
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&family=IBM+Plex+Sans:wght@400;600&family=Fira+Code&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add trailingSlash and 301 redirect rules to canonicalize URLs
- replace catch-all rewrites with server function routing for categories and articles
- provide canonical tags and noindex meta to improve indexability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b57b3cc10083339cfcb737af9a9459