### PR TITLE
Update Gemini flash model version to 1.5-001

### DIFF
--- a/functions/api/routes/ai.js
+++ b/functions/api/routes/ai.js
@@ -35,7 +35,7 @@ router.post('/generateAIAgentResponse', async (req, res) => {
 
     const genAI = new GoogleGenerativeAI(apiKey);
     const model = genAI.getGenerativeModel({
-      model: "gemini-1.5-flash-latest",
+      model: "gemini-1.5-flash-001",
       safetySettings: getSafetySettings()
     });
 

--- a/functions/callable/ai.js
+++ b/functions/callable/ai.js
@@ -65,7 +65,7 @@ async function generateArticleContent(request) { // request contains { auth, dat
       }
       
       const genAI = new GoogleGenerativeAI(apiKey);
-      const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest", safetySettings: getSafetySettings() });
+      const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-001", safetySettings: getSafetySettings() });
 
       const structuredPrompt = `
 Write a professional tech/finance news article about "${topic}" in the style of Yahoo Finance or Bloomberg.
@@ -418,7 +418,7 @@ async function generateTopTenArticle(request) {
         if (!sdkLoaded || !GoogleGenerativeAI) throw new HttpsError("internal", "Core AI SDK failed to load.");
 
         const genAI = new GoogleGenerativeAI(apiKey);
-        const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest", safetySettings: getSafetySettings() });
+        const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-001", safetySettings: getSafetySettings() });
 
         const structuredPrompt = `Create a top ${count} list article about "${topic}" for a technology news website.
 
@@ -507,7 +507,7 @@ async function generateHowToArticle(request) {
         if (!sdkLoaded || !GoogleGenerativeAI) throw new HttpsError("internal", "Core AI SDK failed to load.");
 
         const genAI = new GoogleGenerativeAI(apiKey);
-        const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest", safetySettings: getSafetySettings() });
+        const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-001", safetySettings: getSafetySettings() });
 
         const structuredPrompt = `Create a step-by-step how-to article about "${topic}" for a technology news website.
 

--- a/functions/callable/search.js
+++ b/functions/callable/search.js
@@ -151,7 +151,7 @@ async function getSearchSuggestions(request) {
         }
 
         const genAI = new GoogleGenerativeAI(apiKey);
-        const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" });
+        const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-001" });
 
         // Create context from previous results
         const context = previousResults.length > 0 
@@ -255,7 +255,7 @@ async function getGeminiInsights(query, results) {
         if (!apiKey) return null;
 
         const genAI = new GoogleGenerativeAI(apiKey);
-        const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" });
+        const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-001" });
 
         const resultsContext = results.slice(0, 5).map(r => `- ${r.title}: ${r.excerpt}`).join('\n');
 

--- a/functions/callable/tools.js
+++ b/functions/callable/tools.js
@@ -34,7 +34,7 @@ async function generateAIAgentResponse(request) {
     };
 
     const model = genAI.getGenerativeModel({
-      model: "gemini-1.5-flash-latest", // Use a model that supports tool calling
+      model: "gemini-1.5-flash-001", // Use a model that supports tool calling
       safetySettings: getSafetySettings(),
       tools: tools,
     });
@@ -130,7 +130,7 @@ async function getFinnhubStockData({ data }) {
       if (!geminiKey) throw new HttpsError("internal", "Gemini API Key needed for analysis.");
       
       const genAI = new GoogleGenerativeAI(geminiKey);
-      const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" });
+      const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-001" });
       
       const analysisPrompt = `Analyze the following stock data and provide a brief summary of market sentiment and key trends:\n\n${JSON.stringify(stockData, null, 2)}`;
       const analysisResult = await model.generateContent(analysisPrompt);


### PR DESCRIPTION
## Summary
- update all server-side Gemini flash model references to use the 1.5-001 variant that is available for generateContent
- ensure callable functions, REST endpoints, and tools share the supported model name to avoid API 404 errors

## Testing
- not run (server-side change only)


------
https://chatgpt.com/codex/tasks/task_b_68e37fdc68e0833387b391b7e5bb4d68