### PR TITLE
Switch AI workloads to Gemini 1.5 Flash

### DIFF
--- a/functions/api/routes/ai.js
+++ b/functions/api/routes/ai.js
@@ -99,7 +99,7 @@ Be proactive in offering these options if the user's query is related to "this a
     logger.info("AI Agent HTTP: Sending final prompt to Gemini (first 500 chars):", fullPrompt.substring(0,500));
     const result = await genAI.models.generateContent(
       buildGenerateContentRequest(fullPrompt, {
-        model: "gemini-2.5-flash",
+        model: "gemini-1.5-flash",
         safetySettings: getSafetySettings(),
       }),
     );

--- a/functions/callable/ai.js
+++ b/functions/callable/ai.js
@@ -6,8 +6,7 @@ const { loadGeminiSDK, getSafetySettings, getSafe, getGeminiSDK, getStockMapping
 const fetch = require('node-fetch');
 const { fetchImageFromUnsplash } = require('../services/unsplashService');
 
-const GEMINI_FLASH_MODEL = "gemini-2.5-flash";
-const GEMINI_PRO_MODEL = "gemini-2.5-pro";
+const GEMINI_PRIMARY_MODEL = "gemini-1.5-flash";
 
 // --- Helper function to get fallback colors for SVG generation ---
 function getFallbackImagesForCategory(prompt = "") {
@@ -98,7 +97,7 @@ Generate the article about: "${topic}". Output ONLY the JSON object.
       logger.info("generateArticleContent: Sending structured prompt to Gemini...");
       const result = await genAI.models.generateContent(
         buildGenerateContentRequest(structuredPrompt, {
-          model: GEMINI_FLASH_MODEL,
+          model: GEMINI_PRIMARY_MODEL,
           safetySettings: getSafetySettings(),
         }),
       );
@@ -321,7 +320,7 @@ Output ONLY the SVG code starting with <svg and ending with </svg>. No explanati
         try {
             const result = await genAI.models.generateContent(
                 buildGenerateContentRequest(svgPrompt, {
-                    model: GEMINI_PRO_MODEL,
+                    model: GEMINI_PRIMARY_MODEL,
                     safetySettings: getSafetySettings(),
                 }),
             );
@@ -436,7 +435,7 @@ Output ONLY JSON with keys: title, slug, intro, items, conclusion, tags. Each it
 
         const result = await genAI.models.generateContent(
             buildGenerateContentRequest(structuredPrompt, {
-                model: GEMINI_FLASH_MODEL,
+                model: GEMINI_PRIMARY_MODEL,
                 safetySettings: getSafetySettings(),
             }),
         );
@@ -527,8 +526,8 @@ Requirements:
 Output ONLY JSON with keys: title, slug, intro, steps, conclusion, tags.`;
 
         const result = await genAI.models.generateContent(
-            buildGenerateContentRequest(structuredPrompt, {
-                model: GEMINI_FLASH_MODEL,
+          buildGenerateContentRequest(structuredPrompt, {
+              model: GEMINI_PRIMARY_MODEL,
                 safetySettings: getSafetySettings(),
             }),
         );

--- a/functions/callable/search.js
+++ b/functions/callable/search.js
@@ -182,7 +182,7 @@ async function getSearchSuggestions(request) {
 
         const result = await genAI.models.generateContent(
             buildGenerateContentRequest(prompt, {
-                model: "gemini-2.5-flash",
+                model: "gemini-1.5-flash",
                 safetySettings: getSafetySettings(),
             }),
         );
@@ -288,7 +288,7 @@ async function getGeminiInsights(query, results) {
 
         const result = await genAI.models.generateContent(
             buildGenerateContentRequest(prompt, {
-                model: "gemini-2.5-flash",
+                model: "gemini-1.5-flash",
                 safetySettings: getSafetySettings(),
             }),
         );

--- a/functions/callable/tools.js
+++ b/functions/callable/tools.js
@@ -62,7 +62,7 @@ async function generateAIAgentResponse(request) {
 
     const result = await genAI.models.generateContent(
       buildGenerateContentRequest({ contents: history }, {
-        model: "gemini-2.5-flash",
+        model: "gemini-1.5-flash",
         safetySettings: getSafetySettings(),
         tools,
       }),
@@ -151,7 +151,7 @@ async function getFinnhubStockData({ data }) {
       const analysisPrompt = `Analyze the following stock data and provide a brief summary of market sentiment and key trends:\n\n${JSON.stringify(stockData, null, 2)}`;
       const analysisResult = await genAI.models.generateContent(
         buildGenerateContentRequest(analysisPrompt, {
-          model: "gemini-2.5-flash",
+          model: "gemini-1.5-flash",
         }),
       );
       const analysisText = (typeof analysisResult.text === "function" ? analysisResult.text() : analysisResult.text) || "";


### PR DESCRIPTION
## Summary
- replace uses of the Gemini 2.5 models with the Gemini 1.5 Flash tier for HTTP and callable AI endpoints
- remove the dedicated pro model usage so all site features share the lower-cost configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690705d1fb688333923b68e7d3787605